### PR TITLE
Add upstream vLLM-vs-vLLM comparison pairs to Overview

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -106,6 +106,31 @@ OVERVIEW_RELEASE_PAIRS = [
         "upstream": "vLLM-0.13.0",
         "additional": [],
     },
+    # ── Upstream vLLM-vs-vLLM release pairs ──────────────────────────
+    {
+        "current": "vLLM-0.18.0",
+        "previous": "vLLM-0.17.1",
+        "upstream": None,
+        "additional": [],
+    },
+    {
+        "current": "vLLM-0.17.1",
+        "previous": "vLLM-0.16.0",
+        "upstream": None,
+        "additional": [],
+    },
+    {
+        "current": "vLLM-0.16.0",
+        "previous": "vLLM-0.14.1",
+        "upstream": None,
+        "additional": [],
+    },
+    {
+        "current": "vLLM-0.14.1",
+        "previous": "vLLM-0.13.0",
+        "upstream": None,
+        "additional": [],
+    },
 ]
 
 # ±3 % dead-zone: changes within this range are "neutral" (neither win nor loss)


### PR DESCRIPTION
## Summary
- Adds four upstream vLLM-vs-vLLM release comparison pairs to the Overview dropdown, so users can track performance changes across consecutive vLLM releases directly:
  - **vLLM-0.18.0 vs vLLM-0.17.1**
  - **vLLM-0.17.1 vs vLLM-0.16.0**
  - **vLLM-0.16.0 vs vLLM-0.14.1**
  - **vLLM-0.14.1 vs vLLM-0.13.0**
- These reuse the existing comparison engine (`_compute_overview_data`) with no code changes — only config additions to `OVERVIEW_RELEASE_PAIRS`
- The vLLM Parity Scorecard section is correctly skipped (`upstream=None`) since there is no separate upstream for vLLM-vs-vLLM pairs

## Prerequisite
The `consolidated_dashboard.csv` (S3) must contain benchmark data rows tagged with these vLLM version strings for the pairs to appear in the dropdown (filtered by `_available_overview_pairs`).

## Test plan
- [ ] Verify the new pairs appear in the Overview dropdown when matching data exists in the CSV
- [ ] Confirm KPI cards, heatmap, and family/accelerator rollups render correctly for vLLM-vs-vLLM pairs
- [ ] Confirm the vLLM Parity Scorecard shows "not available" for these pairs (expected — no upstream to compare)
- [ ] Verify existing RHAIIS-vs-RHAIIS pairs still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Overview release-pair dropdown now includes additional consecutive release comparisons, expanding the list of available release pairs for performance comparison. This enhancement provides users with increased flexibility in selecting and analyzing different release combinations, enabling more detailed performance analysis and offering deeper insights into release-to-release performance variations and trends across vLLM versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->