### PR TITLE
Add H200 Hera cluster support with cluster-specific Grafana links

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -81,15 +81,21 @@ S3_LOGS_BUCKET = os.environ.get("S3_LOGS_BUCKET", "psap-model-furnace")
 S3_LOGS_PREFIX = os.environ.get("S3_LOGS_PREFIX", "logs/")
 
 # ── Overview version configuration (single source of truth) ──────
-OVERVIEW_CURRENT = "RHAIIS-3.4-EA2"
-OVERVIEW_PREVIOUS = "RHAIIS-3.4-EA1"
-OVERVIEW_UPSTREAM = "vLLM-0.16.0"
+OVERVIEW_CURRENT = "RHAIIS-3.4-GA"
+OVERVIEW_PREVIOUS = "RHAIIS-3.4-EA2"
+OVERVIEW_UPSTREAM = "vLLM-0.18.0"
 OVERVIEW_ADDITIONAL = ["vLLM-0.17.1"]
 
 # Ordered list of back-to-back release pairs for the Overview dropdown.
 # Most recent pair first. `upstream` / `additional` can be None / [] when
 # vLLM parity data isn't available for that release.
 OVERVIEW_RELEASE_PAIRS = [
+    {
+        "current": "RHAIIS-3.4-GA",
+        "previous": "RHAIIS-3.4-EA2",
+        "upstream": "vLLM-0.18.0",
+        "additional": ["vLLM-0.17.1"],
+    },
     {
         "current": "RHAIIS-3.4-EA2",
         "previous": "RHAIIS-3.4-EA1",
@@ -233,7 +239,7 @@ def fetch_log_from_s3(uuid_str: str) -> tuple:
         return (False, "boto3 is required for S3 access.")
     except Exception as e:
         err = str(e)
-        if "NoSuchKey" in err or "404" in err or "Not Found" in err:
+        if any(k in err for k in ("NoSuchKey", "404", "Not Found", "AccessDenied")):
             return (False, f"Log not available for UUID: {uuid_str}")
         return (False, f"Failed to fetch log: {err}")
 
@@ -812,14 +818,14 @@ def _compute_overview_data(
         )
         awr = ((at - al) / at * 100) if at > 0 else 100.0
 
-        worst_m, worst_v = None, 0.0
+        worst_m, worst_v, worst_raw = None, 0.0, 0.0
         for r in ar:
             for mname, mc in metrics_cfg.items():
                 pct = r.get(f"{mname}_pct")
                 if pct is not None:
                     norm = pct if mc["higher_is_better"] else -pct
                     if norm < worst_v:
-                        worst_v, worst_m = norm, mname
+                        worst_v, worst_m, worst_raw = norm, mname, pct
 
         ah = "Healthy" if awr >= 90 else ("Warning" if awr >= 70 else "Regression")
         accel_rollup[accel] = {
@@ -829,6 +835,7 @@ def _compute_overview_data(
             "health": ah,
             "worst_metric": worst_m,
             "worst_val": worst_v,
+            "worst_raw_pct": worst_raw,
             "results": ar,
         }
 
@@ -2187,8 +2194,11 @@ Changes within ±{NEUTRAL_THRESHOLD_PCT:.0f} % are not counted as losses.<br><br
     # ── Per-Accelerator Health Cards ────────────────────────────────
     st.markdown("### Performance by Accelerator")
     st.caption(
-        "Per-accelerator rollup averaged across all models and profiles — "
-        "status is determined by worst regression across all models."
+        "Per-accelerator rollup comparing the current release to the previous one. "
+        "**Avg Tput** is the mean throughput change across all combinations "
+        "(model × accelerator × profile). "
+        "**Win Rate** is the percentage of combinations where throughput improved. "
+        "Click any accelerator card to drill down into per-combo details."
     )
     accel_cols = st.columns(len(data["accel_rollup"]) or 1)
     for idx, (accel, info) in enumerate(data["accel_rollup"].items()):
@@ -2205,50 +2215,80 @@ Changes within ±{NEUTRAL_THRESHOLD_PCT:.0f} % are not counted as losses.<br><br
             }[info["health"]]
             dots = _health_dots_html(info["health"])
 
-            worst_line = ""
-            if info["worst_metric"] and info["worst_val"] < 0:
-                worst_line = (
+            worst_label = _METRIC_SHORT.get(
+                info["worst_metric"], info["worst_metric"] or ""
+            )
+            worst_line = (
+                (
                     f'<div class="family-card-stat">'
-                    f"Worst: <b>{info['worst_metric']}</b> {info['worst_val']:+.1f} %"
+                    f"Worst: <b>{worst_label}</b> {info['worst_raw_pct']:+.1f} %"
                     f"</div>"
                 )
+                if info["worst_metric"]
+                else ""
+            )
 
-            # Per-model throughput breakdown for this accelerator
-            seen_models = {}
-            for r in info["results"]:
-                key = r["short_name"]
-                if key not in seen_models:
-                    seen_models[key] = []
+            wr_cls = (
+                "val-green"
+                if info["win_rate"] >= 90
+                else ("val-red" if info["win_rate"] < 70 else "")
+            )
+            tput_cls = "val-green" if info["avg_tput_pct"] >= 0 else "val-red"
+
+            accel_families = sorted(
+                {_model_family(r["model"]) for r in info["results"]}
+            )
+            accel_profiles = sorted(
+                {
+                    _display_profile(r["profile"], r.get("custom_isl_osl", ""))
+                    for r in info["results"]
+                }
+            )
+            n_combos = len(info["results"])
+
+            detail_lines = ""
+            for r in sorted(
+                info["results"], key=lambda x: (x["short_name"], x["profile"])
+            ):
                 pct = r.get("Throughput_pct")
-                if pct is not None:
-                    seen_models[key].append(pct)
-            model_lines = ""
-            for mname, pcts in sorted(seen_models.items()):
-                avg = float(np.mean(pcts)) if pcts else 0
+                if pct is None:
+                    continue
                 icon = (
                     "🟢"
-                    if avg > NEUTRAL_THRESHOLD_PCT
-                    else ("🟡" if avg >= -NEUTRAL_THRESHOLD_PCT else "🔴")
+                    if pct > NEUTRAL_THRESHOLD_PCT
+                    else ("🟡" if pct >= -NEUTRAL_THRESHOLD_PCT else "🔴")
                 )
-                model_lines += f"• {icon} <b>{mname}</b>: {avg:+.1f} % throughput<br>"
+                prof = _display_profile(r["profile"], r.get("custom_isl_osl", ""))
+                detail_lines += (
+                    f"• {icon} <b>{r['short_name']}</b> "
+                    f"TP{r['tp']} · {prof}: "
+                    f"{pct:+.1f} %<br>"
+                )
 
-            tput_cls = "val-green" if info["avg_tput_pct"] >= 0 else "val-red"
             st.markdown(
                 f"""<div class="overview-family-card {status_cls}"><details><summary>
 <div class="family-card-header">
 <span class="family-card-name">{_accel_display(accel)}</span>
 <span>{dots} <span class="family-card-badge {badge_cls}">{info["health"]}</span></span>
 </div>
-<div class="family-card-stat">{info["n_models"]} model(s) &nbsp;&nbsp; Avg Tput: <b class="{tput_cls}">{info["avg_tput_pct"]:+.1f} %</b></div>
-                    {worst_line}
-                    <div class="family-card-stat">Win Rate: <b>{info["win_rate"]:.0f} %</b></div>
-                </summary>
-                <div class="overview-card-detail">
-                    Per-model throughput delta:<br><br>
-                    {model_lines}
-                </div></details></div>""",
+<div class="family-card-stat">{info["n_models"]} model{"s" if info["n_models"] != 1 else ""} &nbsp;&nbsp; Avg Tput: <b class="{tput_cls}">{info["avg_tput_pct"]:+.1f} %</b></div>
+{worst_line}
+<div class="family-card-stat">Competitive Win Rate: <b class="{wr_cls}">{info["win_rate"]:.0f} %</b></div>
+</summary>
+<div class="overview-card-detail">
+<b>Coverage:</b> {", ".join(accel_families)} &mdash; {n_combos} combo{"s" if n_combos != 1 else ""} across {", ".join(accel_profiles)}<br><br>
+<b>Per-combo throughput delta (geometric mean):</b><br><br>
+{detail_lines}
+</div></details></div>""",
                 unsafe_allow_html=True,
             )
+    st.caption(
+        "**Worst** shows the single largest regression across Throughput, TTFT, and ITL "
+        "(the specific metric varies by accelerator). "
+        f"Changes within ±{NEUTRAL_THRESHOLD_PCT:.0f} % are excluded from win/loss (neutral). "
+        "**Status** is derived from win rate: "
+        "Healthy ≥ 90 %, Warning ≥ 70 %, Regression < 70 %."
+    )
 
     st.markdown("---")
 
@@ -6478,7 +6518,14 @@ def render_cost_analysis_section(filtered_df, accelerator_color_map, use_expande
         col1, col2 = st.columns([4, 1])
         with col1:
             st.markdown(
-                "💡 **Cost Methodology**: Based on PSAP AI Costs Dashboard methodology - throughput performance at optimal concurrency that meets PSAP latency SLOs."
+                "💡 **Cost Methodology**: Based on PSAP AI Costs Dashboard methodology - throughput performance "
+                "at optimal concurrency. Converts actual throughput numbers (under a latency constraint) "
+                "for a model + GPU combination into time to generate one million tokens, then into USD per "
+                "million tokens. The time-to-cost conversion uses hourly on-demand cloud-instance pricing, "
+                "which provides a convenient comparison point to API-provider costs (also quoted per million "
+                "tokens). **For GPU sizing guidance and an alternative cost model that estimates the number of "
+                "GPUs needed to meet throughput / SLO requirements and converts to on-prem vs. cloud costs, "
+                "see [GPU Infer](https://nb-qbits.github.io/gpuinfer/).**"
             )
         with col2, st.popover("ℹ️ Formulas"):
             st.markdown(
@@ -8676,6 +8723,11 @@ def render_filtered_data_section(filtered_df, use_expander=True):
                 "dashboard_id": "7a3b910e7e827c",
                 "dashboard_name": "vllm-2b-dcgm-metrics-psap-rhaiis-h200",
             },
+            "H200_HERA": {
+                "dashboard_id": "7a3b910e7e827c",
+                "dashboard_name": "vllm-2b-dcgm-metrics-psap-rhaiis-h200",
+                "extra_params": "&var-cluster_name=$__all",
+            },
             "MI300X": {
                 "dashboard_id": "amd-ods-az-amd-01",
                 "dashboard_name": "vllm-2b-rocm-gpu-metrics-ods-az-amd-01",
@@ -8689,12 +8741,20 @@ def render_filtered_data_section(filtered_df, use_expander=True):
         # Jan 1, 2026 00:00:00 UTC in milliseconds
         H200_DASHBOARD_CUTOFF_MS = 1767225600000
 
+        def _is_hera_run(run_name):
+            """Check if a run belongs to the H200 Hera cluster."""
+            if not isinstance(run_name, str):
+                return False
+            upper = run_name.upper()
+            return upper.startswith("H200-HERA-") or upper.startswith("H200_HERA-")
+
         def create_grafana_link(row):
             """Create Grafana dashboard link if timestamps are available."""
             start_time = row.get("guidellm_start_time_ms")
             end_time = row.get("guidellm_end_time_ms")
             uuid = row.get("uuid")
             accelerator = row.get("accelerator", "")
+            run_name = row.get("run", "")
 
             # Only create link if all required fields are present and not NaN
             if (
@@ -8709,9 +8769,10 @@ def render_filtered_data_section(filtered_df, use_expander=True):
                 start_ms = int(start_time)
                 end_ms = int(end_time)
 
-                # Determine which dashboard to use based on accelerator and date
-                if accelerator == "H200":
-                    # Use new dashboard for runs on or after Jan 1, 2026
+                # Determine which dashboard to use based on accelerator, cluster, and date
+                if _is_hera_run(run_name):
+                    dashboard_key = "H200_HERA"
+                elif accelerator == "H200":
                     if start_ms >= H200_DASHBOARD_CUTOFF_MS:
                         dashboard_key = "H200_NEW"
                     else:
@@ -8724,6 +8785,7 @@ def render_filtered_data_section(filtered_df, use_expander=True):
                 dashboard_config = GRAFANA_DASHBOARDS[dashboard_key]
                 dashboard_id = dashboard_config["dashboard_id"]
                 dashboard_name = dashboard_config["dashboard_name"]
+                extra_params = dashboard_config.get("extra_params", "")
 
                 # Build URL with accelerator-specific dashboard
                 base_url = "https://grafana-psap-obs.apps.ocp4.intlab.redhat.com"
@@ -8732,6 +8794,7 @@ def render_filtered_data_section(filtered_df, use_expander=True):
                     f"?orgId=1&from={start_ms}&to={end_ms}"
                     f"&timezone=browser&var-deployment_uuid={uuid}"
                     f"&var-deployment_pod_name=$__all&var-rate_interval=1m"
+                    f"{extra_params}"
                 )
             return None
 
@@ -9072,7 +9135,10 @@ def render_confidentiality_notice():
         '<b style="color: #92400e;">Performance Data Disclaimer</b> — '
         "Red Hat Confidential. Disclosure requires signed NDA. "
         "External publication needs PSAP Inference Team approval "
-        '(<span style="color:#92400e;">@psap-inference</span> on #forum-psap).'
+        '(<span style="color:#92400e;">@psap-inference</span> on #forum-psap). '
+        "<b>For GPU sizing guidance and cost analysis, see "
+        '<a href="https://nb-qbits.github.io/gpuinfer/" target="_blank" '
+        'style="color:#92400e;text-decoration:underline;">GPU Infer</a>.</b>'
         "</div>",
         unsafe_allow_html=True,
     )

--- a/manual_runs/scripts/import_manual_run_jsons_old.py
+++ b/manual_runs/scripts/import_manual_run_jsons_old.py
@@ -22,6 +22,7 @@ def process_benchmark_section(
     tp_size,
     runtime_args,
     benchmark_index,
+    cluster=None,
 ):
     """Process a single benchmark section and extract performance metrics.
 
@@ -33,11 +34,15 @@ def process_benchmark_section(
         tp_size: Tensor parallelism size.
         runtime_args: Runtime configuration arguments.
         benchmark_index: Index of the benchmark run.
+        cluster: Optional cluster name (e.g., 'hera').
 
     Returns:
         dict: Processed benchmark metrics.
     """
-    full_model_name = f"{accelerator}-{model_name}-{tp_size}"
+    if cluster:
+        full_model_name = f"{accelerator}-{cluster}-{model_name}-{tp_size}"
+    else:
+        full_model_name = f"{accelerator}-{model_name}-{tp_size}"
 
     profile_args = benchmark_run.get("args", {}).get("profile", {})
     uuid = benchmark_run.get("run_id")
@@ -142,7 +147,7 @@ def process_benchmark_section(
 
 
 def parse_guidellm_json(
-    json_path, accelerator, model_name, version, tp_size, runtime_args
+    json_path, accelerator, model_name, version, tp_size, runtime_args, cluster=None
 ):
     """Parse GuideLL JSON benchmark results.
 
@@ -153,6 +158,7 @@ def parse_guidellm_json(
         version: Version of the inference server.
         tp_size: Tensor parallelism size.
         runtime_args: Runtime configuration arguments.
+        cluster: Optional cluster name (e.g., 'hera').
 
     Returns:
         list: List of processed benchmark results.
@@ -182,7 +188,14 @@ def parse_guidellm_json(
 
     for i, benchmark_run in enumerate(benchmarks):
         row_data = process_benchmark_section(
-            benchmark_run, accelerator, model_name, version, tp_size, runtime_args, i
+            benchmark_run,
+            accelerator,
+            model_name,
+            version,
+            tp_size,
+            runtime_args,
+            i,
+            cluster=cluster,
         )
         if row_data:
             all_run_data.append(row_data)
@@ -222,6 +235,12 @@ def main():
         "--accelerator", required=True, help="Accelerator type (e.g., 'H100', 'A100')"
     )
     parser.add_argument(
+        "--cluster",
+        default=None,
+        help="Optional cluster name to distinguish runs on different clusters "
+        "(e.g., 'hera'). When set, the run column becomes <accelerator>-<cluster>-<model>-<tp>.",
+    )
+    parser.add_argument(
         "--runtime-args",
         required=True,
         help="Runtime arguments used for the inference server (e.g., 'tensor-parallel-size: 8; max-model-len: 8192; trust-remote-code: True')",
@@ -242,6 +261,7 @@ def main():
         args.version,
         args.tp,
         args.runtime_args,
+        cluster=args.cluster,
     )
 
     if new_data_df is not None and not new_data_df.empty:

--- a/manual_runs/scripts/import_manual_runs_json_v2.py
+++ b/manual_runs/scripts/import_manual_runs_json_v2.py
@@ -46,7 +46,7 @@ def process_benchmark_section(
     Returns:
         dict: Processed benchmark metrics.
     """
-    parallelism_tag = tp_size if tp_size is not None else dp_size
+    parallelism_tag = f"tp{tp_size}" if tp_size is not None else f"dp{dp_size}"
     full_model_name = f"{accelerator}-{model_name}-{parallelism_tag}"
 
     config = benchmark.get("config", {})

--- a/manual_runs/scripts/import_manual_runs_json_v2.py
+++ b/manual_runs/scripts/import_manual_runs_json_v2.py
@@ -46,7 +46,7 @@ def process_benchmark_section(
     Returns:
         dict: Processed benchmark metrics.
     """
-    parallelism_tag = f"tp{tp_size}" if tp_size is not None else f"dp{dp_size}"
+    parallelism_tag = tp_size if tp_size is not None else dp_size
     full_model_name = f"{accelerator}-{model_name}-{parallelism_tag}"
 
     config = benchmark.get("config", {})

--- a/manual_runs/scripts/import_manual_runs_json_v2.py
+++ b/manual_runs/scripts/import_manual_runs_json_v2.py
@@ -26,6 +26,7 @@ def process_benchmark_section(
     guidellm_start_time_ms,
     guidellm_end_time_ms,
     dp_size=None,
+    cluster=None,
 ):
     """Process a single benchmark section and extract performance metrics.
 
@@ -42,12 +43,16 @@ def process_benchmark_section(
         guidellm_start_time_ms: Aggregated start time in milliseconds.
         guidellm_end_time_ms: Aggregated end time in milliseconds.
         dp_size: Data parallelism size (None for TP runs).
+        cluster: Optional cluster name (e.g., 'hera') to distinguish runs on different clusters.
 
     Returns:
         dict: Processed benchmark metrics.
     """
     parallelism_tag = tp_size if tp_size is not None else dp_size
-    full_model_name = f"{accelerator}-{model_name}-{parallelism_tag}"
+    if cluster:
+        full_model_name = f"{accelerator}-{cluster}-{model_name}-{parallelism_tag}"
+    else:
+        full_model_name = f"{accelerator}-{model_name}-{parallelism_tag}"
 
     config = benchmark.get("config", {})
     uuid = config.get("run_id")
@@ -182,6 +187,7 @@ def parse_guidellm_json(
     image_tag,
     guidellm_version,
     dp_size=None,
+    cluster=None,
 ):
     """Parse guidellm 0.5.x JSON benchmark results.
 
@@ -195,6 +201,7 @@ def parse_guidellm_json(
         image_tag: Container image tag used for the run.
         guidellm_version: Version of guidellm used to run the benchmark.
         dp_size: Data parallelism size (None for TP runs).
+        cluster: Optional cluster name (e.g., 'hera').
 
     Returns:
         DataFrame: Processed benchmark results.
@@ -256,6 +263,7 @@ def parse_guidellm_json(
             guidellm_start_time_ms,
             guidellm_end_time_ms,
             dp_size=dp_size,
+            cluster=cluster,
         )
         if row_data:
             all_run_data.append(row_data)
@@ -312,6 +320,12 @@ def main():
         "--accelerator", required=True, help="Accelerator type (e.g., 'H200', 'MI300X')"
     )
     parser.add_argument(
+        "--cluster",
+        default=None,
+        help="Optional cluster name to distinguish runs on different clusters "
+        "(e.g., 'hera'). When set, the run column becomes <accelerator>-<cluster>-<model>-<tp>.",
+    )
+    parser.add_argument(
         "--runtime-args",
         required=True,
         help="Runtime arguments used for the inference server",
@@ -353,6 +367,7 @@ def main():
         args.image_tag,
         args.guidellm_version,
         dp_size=args.dp,
+        cluster=args.cluster,
     )
 
     if new_data_df is not None and not new_data_df.empty:


### PR DESCRIPTION
## Summary

Adds support for the new H200 Hera cluster (`H200_HERA`) while keeping `accelerator=H200` in the CSV for filtering and charts. Hera runs are distinguished via the `run` column prefix (`H200-hera-<model>-<tp>`) and routed to the correct Grafana dashboard with the `var-cluster_name` parameter.

### Changes

- **`dashboard.py`**: Added `H200_HERA` entry to `GRAFANA_DASHBOARDS` with `extra_params` for the cluster name variable. Added `_is_hera_run()` helper (case-insensitive) to detect Hera runs from the `run` column and route them to the correct Grafana dashboard.

- **`import_manual_runs_json_v2.py`** / **`import_manual_run_jsons_old.py`**: Added optional `--cluster` CLI argument. When provided (e.g., `--cluster hera`), the run column becomes `<accelerator>-<cluster>-<model>-<tp>` while the `accelerator` column remains unchanged.

### How it works

| Source | `accelerator` column | `run` column | Grafana link |
|---|---|---|---|
| H200 (existing) | `H200` | `H200-<model>-<tp>` | Existing H200 dashboard |
| H200 Hera (new) | `H200` | `H200-hera-<model>-<tp>` | Same dashboard + `var-cluster_name=$__all` |

### Usage (manual imports)

```bash
python import_manual_runs_json_v2.py results.json \
  --accelerator H200 --cluster hera \
  --model meta-llama/Llama-3.3-70B-Instruct \
  --version RHAIIS-3.4-GA --tp 8 ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added H200_HERA dashboard configuration for Grafana links
  * Extended manual run imports with optional cluster parameter to distinguish runs across clusters
  * Expanded Cost Analysis tooltip with additional guidance

* **Bug Fixes**
  * Improved S3 log error detection to handle broader "not found/access denied" scenarios

* **Updates**
  * Updated release versions: RHAIIS to 3.4-GA and vLLM to 0.18.0
  * Enhanced metrics display to show raw worst metric percentages per accelerator
  * Updated UI rendering for per-combo throughput details
  * Added GPU Infer documentation link to confidentiality notice

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-psap/performance-dashboard/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->