### PR TITLE
Fix Hera Grafana links, compare-versions UI improvements, and URL filter fixes

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1672,7 +1672,7 @@ def render_competitive_analysis_section(df):
                                 )
 
                                 st.markdown(
-                                    "**📊 Click a metric below to open a detailed comparison graph:**"
+                                    "**📊 View detailed graphs** — click any metric to compare across concurrency levels:"
                                 )
                                 btn_metrics = list(metrics_config.keys())
                                 btn_cols = st.columns(len(btn_metrics))
@@ -1684,6 +1684,7 @@ def render_competitive_analysis_section(df):
                                             f"📊 {short}",
                                             key=btn_key,
                                             use_container_width=True,
+                                            type="primary",
                                         ):
                                             _show_ca_metric_dialog(
                                                 m_name,
@@ -4848,7 +4849,7 @@ def render_compare_versions_summary_section(df, use_expander=True):
                 mcfg = metrics_config[metric_name]
                 col = mcfg["column"]
                 agg = mcfg["aggregation"]
-                mcfg["higher_is_better"]
+                _ = mcfg["higher_is_better"]
 
                 # Clean title: strip aggregation suffix, add "vs Concurrency"
                 display_title = metric_name.replace(" (Geometric Mean)", "").replace(
@@ -5060,7 +5061,7 @@ def render_compare_versions_summary_section(df, use_expander=True):
 
             # --- Metric comparison buttons ---
             st.markdown(
-                "**📊 Click a metric below to open a detailed comparison popup:**"
+                "**📊 View detailed graphs** — click any metric to compare across concurrency levels:"
             )
             # Exclude "Peak Output Throughput" (same underlying graph as
             # Output Throughput since both use output_tok/sec vs concurrency)
@@ -5075,6 +5076,7 @@ def render_compare_versions_summary_section(df, use_expander=True):
                         f"📊 {short}",
                         key=f"cmp_btn_{i}",
                         use_container_width=True,
+                        type="primary",
                     ):
                         st.session_state.compare_versions_summary_expanded = True
                         _show_metric_dialog(m_name)
@@ -5815,7 +5817,7 @@ def render_compare_models_section(filtered_df, selected_profile, use_expander=Tr
 
             # --- Metric comparison buttons ---
             st.markdown(
-                "**📊 Click a metric below to open a detailed comparison popup:**"
+                "**📊 View detailed graphs** — click any metric to compare across concurrency levels:"
             )
             btn_metrics = [m for m in metrics_config if m != "Peak Output Throughput"]
             btn_cols = st.columns(len(btn_metrics))
@@ -5828,6 +5830,7 @@ def render_compare_models_section(filtered_df, selected_profile, use_expander=Tr
                         f"📊 {short}",
                         key=f"cmp_models_btn_{i}",
                         use_container_width=True,
+                        type="primary",
                     ):
                         st.session_state.compare_models_expanded = True
                         _show_model_metric_dialog(m_name)
@@ -8724,9 +8727,8 @@ def render_filtered_data_section(filtered_df, use_expander=True):
                 "dashboard_name": "vllm-2b-dcgm-metrics-psap-rhaiis-h200",
             },
             "H200_HERA": {
-                "dashboard_id": "7a3b910e7e827c",
-                "dashboard_name": "vllm-2b-dcgm-metrics-psap-rhaiis-h200",
-                "extra_params": "&var-cluster_name=$__all",
+                "dashboard_id": "cd77e3aa2b40e0",
+                "dashboard_name": "vllm-2b-dcgm-metrics-rhaiis-ibm-dc-h200",
             },
             "MI300X": {
                 "dashboard_id": "amd-ods-az-amd-01",
@@ -9479,11 +9481,15 @@ def main():
 
             if "tp_sizes" in query_params:
                 try:
-                    url_tp_sizes = [
-                        int(tp.strip())
-                        for tp in query_params["tp_sizes"].split(",")
-                        if tp.strip().isdigit() and int(tp.strip()) in all_tp_sizes
-                    ]
+                    parsed = []
+                    for tp in query_params["tp_sizes"].split(","):
+                        val = float(tp.strip())
+                        int_val = int(val)
+                        if int_val in all_tp_sizes:
+                            parsed.append(int_val)
+                        elif val in all_tp_sizes:
+                            parsed.append(val)
+                    url_tp_sizes = parsed
                 except:
                     url_tp_sizes = []
 
@@ -10187,10 +10193,12 @@ def main():
             prev_selected_tp = st.session_state.get(prev_tp_key, None)
 
             # Check if models selection changed
+            # On first load (prev is None), don't treat URL-provided models as a "change"
+            # so we preserve the URL-based TP selection instead of selecting all.
             models_changed = (
                 (prev_selected_models != selected_models)
                 if prev_selected_models is not None
-                else (bool(selected_models))
+                else False
             )
 
             if st.session_state.get("clear_all_filters", False) or st.session_state.get(

--- a/dashboard_styles.py
+++ b/dashboard_styles.py
@@ -931,6 +931,60 @@ def get_app_css():
         border-color: #e1e5e9 !important;
     }
 
+    /* ── Compare / graph action buttons ── */
+    @keyframes cmpBtnFadeIn {
+        from { opacity: 0; transform: translateY(6px); }
+        to   { opacity: 1; transform: translateY(0); }
+    }
+    [class*="st-key-cmp_btn_"] button,
+    [class*="st-key-cmp_models_btn_"] button,
+    [class*="st-key-ca_btn_"] button {
+        background: linear-gradient(135deg, #4a6fa5 0%, #3b5998 100%) !important;
+        color: #ffffff !important;
+        border: none !important;
+        border-radius: 8px !important;
+        padding: 0.6rem 1rem !important;
+        font-weight: 600 !important;
+        font-size: 0.85rem !important;
+        letter-spacing: 0.01em !important;
+        box-shadow: 0 2px 6px rgba(59, 89, 152, 0.25) !important;
+        transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1) !important;
+        cursor: pointer !important;
+        animation: cmpBtnFadeIn 0.4s ease-out both !important;
+    }
+    [class*="st-key-cmp_btn_0"] button,
+    [class*="st-key-cmp_models_btn_0"] button { animation-delay: 0s !important; }
+    [class*="st-key-cmp_btn_1"] button,
+    [class*="st-key-cmp_models_btn_1"] button { animation-delay: 0.06s !important; }
+    [class*="st-key-cmp_btn_2"] button,
+    [class*="st-key-cmp_models_btn_2"] button { animation-delay: 0.12s !important; }
+    [class*="st-key-cmp_btn_3"] button,
+    [class*="st-key-cmp_models_btn_3"] button { animation-delay: 0.18s !important; }
+    [class*="st-key-cmp_btn_4"] button,
+    [class*="st-key-cmp_models_btn_4"] button { animation-delay: 0.24s !important; }
+    [class*="st-key-cmp_btn_"] button:hover,
+    [class*="st-key-cmp_models_btn_"] button:hover,
+    [class*="st-key-ca_btn_"] button:hover {
+        background: linear-gradient(135deg, #3b5998 0%, #2d4373 100%) !important;
+        box-shadow: 0 4px 14px rgba(59, 89, 152, 0.40) !important;
+        transform: translateY(-2px) !important;
+        color: #ffffff !important;
+    }
+    [class*="st-key-cmp_btn_"] button:active,
+    [class*="st-key-cmp_models_btn_"] button:active,
+    [class*="st-key-ca_btn_"] button:active {
+        transform: translateY(0px) !important;
+        box-shadow: 0 1px 4px rgba(59, 89, 152, 0.25) !important;
+    }
+    [class*="st-key-cmp_btn_"] button p,
+    [class*="st-key-cmp_btn_"] button span,
+    [class*="st-key-cmp_models_btn_"] button p,
+    [class*="st-key-cmp_models_btn_"] button span,
+    [class*="st-key-ca_btn_"] button p,
+    [class*="st-key-ca_btn_"] button span {
+        color: #ffffff !important;
+    }
+
     </style>
     """
 
@@ -1171,6 +1225,29 @@ def get_dark_mode_css():
     .kpi-value {
         color: #58a6ff !important;
     }
+
+    /* Preserve graph button styling in dark mode */
+    [class*="st-key-cmp_btn_"] button,
+    [class*="st-key-cmp_models_btn_"] button,
+    [class*="st-key-ca_btn_"] button {
+        background: linear-gradient(135deg, #4a6fa5 0%, #3b5998 100%) !important;
+        color: #ffffff !important;
+        border: none !important;
+    }
+    [class*="st-key-cmp_btn_"] button:hover,
+    [class*="st-key-cmp_models_btn_"] button:hover,
+    [class*="st-key-ca_btn_"] button:hover {
+        background: linear-gradient(135deg, #3b5998 0%, #2d4373 100%) !important;
+        color: #ffffff !important;
+    }
+    [class*="st-key-cmp_btn_"] button p,
+    [class*="st-key-cmp_btn_"] button span,
+    [class*="st-key-cmp_models_btn_"] button p,
+    [class*="st-key-cmp_models_btn_"] button span,
+    [class*="st-key-ca_btn_"] button p,
+    [class*="st-key-ca_btn_"] button span {
+        color: #ffffff !important;
+    }
     </style>
     """
 
@@ -1279,6 +1356,29 @@ def get_light_mode_css():
         background-color: #ffffff !important;
         color: #1a1f36 !important;
         border: 1px solid #d1d5db !important;
+    }
+
+    /* Preserve graph button styling in light mode */
+    [class*="st-key-cmp_btn_"] button,
+    [class*="st-key-cmp_models_btn_"] button,
+    [class*="st-key-ca_btn_"] button {
+        background: linear-gradient(135deg, #4a6fa5 0%, #3b5998 100%) !important;
+        color: #ffffff !important;
+        border: none !important;
+    }
+    [class*="st-key-cmp_btn_"] button:hover,
+    [class*="st-key-cmp_models_btn_"] button:hover,
+    [class*="st-key-ca_btn_"] button:hover {
+        background: linear-gradient(135deg, #3b5998 0%, #2d4373 100%) !important;
+        color: #ffffff !important;
+    }
+    [class*="st-key-cmp_btn_"] button p,
+    [class*="st-key-cmp_btn_"] button span,
+    [class*="st-key-cmp_models_btn_"] button p,
+    [class*="st-key-cmp_models_btn_"] button span,
+    [class*="st-key-ca_btn_"] button p,
+    [class*="st-key-ca_btn_"] button span {
+        color: #ffffff !important;
     }
 
     /* Override metrics */
@@ -1599,6 +1699,41 @@ def get_light_mode_css():
     /* Ensure button text is visible */
     .stButton button span {
         color: #1a1f36 !important;
+    }
+
+    /* Re-apply graph button styling (after catch-all overrides) */
+    [class*="st-key-cmp_btn_"] button,
+    [class*="st-key-cmp_models_btn_"] button,
+    [class*="st-key-ca_btn_"] button,
+    div[data-testid="stColumn"] [class*="st-key-cmp_btn_"] button,
+    div[data-testid="stColumn"] [class*="st-key-cmp_models_btn_"] button,
+    div[data-testid="stColumn"] [class*="st-key-ca_btn_"] button {
+        background: linear-gradient(135deg, #4a6fa5 0%, #3b5998 100%) !important;
+        color: #ffffff !important;
+        border: none !important;
+        border-radius: 8px !important;
+        box-shadow: 0 2px 6px rgba(59, 89, 152, 0.25) !important;
+    }
+    [class*="st-key-cmp_btn_"] button:hover,
+    [class*="st-key-cmp_models_btn_"] button:hover,
+    [class*="st-key-ca_btn_"] button:hover,
+    div[data-testid="stColumn"] [class*="st-key-cmp_btn_"] button:hover,
+    div[data-testid="stColumn"] [class*="st-key-cmp_models_btn_"] button:hover,
+    div[data-testid="stColumn"] [class*="st-key-ca_btn_"] button:hover {
+        background: linear-gradient(135deg, #3b5998 0%, #2d4373 100%) !important;
+        color: #ffffff !important;
+        box-shadow: 0 4px 14px rgba(59, 89, 152, 0.40) !important;
+    }
+    [class*="st-key-cmp_btn_"] button p,
+    [class*="st-key-cmp_btn_"] button span,
+    [class*="st-key-cmp_models_btn_"] button p,
+    [class*="st-key-cmp_models_btn_"] button span,
+    [class*="st-key-ca_btn_"] button p,
+    [class*="st-key-ca_btn_"] button span,
+    .stButton [class*="st-key-cmp_btn_"] button span,
+    .stButton [class*="st-key-cmp_models_btn_"] button span,
+    .stButton [class*="st-key-ca_btn_"] button span {
+        color: #ffffff !important;
     }
 
     /* Re-apply specific colors for important elements */

--- a/manual_runs/scripts/import_manual_runs_json_v2.py
+++ b/manual_runs/scripts/import_manual_runs_json_v2.py
@@ -48,7 +48,7 @@ def process_benchmark_section(
     Returns:
         dict: Processed benchmark metrics.
     """
-    parallelism_tag = tp_size if tp_size is not None else dp_size
+    parallelism_tag = f"tp{tp_size}" if tp_size is not None else f"dp{dp_size}"
     if cluster:
         full_model_name = f"{accelerator}-{cluster}-{model_name}-{parallelism_tag}"
     else:


### PR DESCRIPTION
Summary
Fix H200 Hera Grafana dashboard links — Updated H200_HERA config to point to the correct hera cluster dashboard .
Improve Compare Versions metric buttons — Styled graph buttons with gradient design, hover animations, and consistent light/dark mode support
Fix URL TP size filter parsing — Handle float TP values in URL query params (previously only accepted integers)
Preserve URL-based TP selection on first load — Don't reset TP filters when models are provided via URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TP auto-selection logic to prevent override on initial page load
  * Improved URL filter decoding for tensor parallel sizes handling

* **UI/UX Improvements**
  * Enhanced comparison and graph buttons with gradient styling, hover effects, and fade-in animations
  * Updated UI copy in Competitive Analysis, Compare Versions, and Compare Models sections

* **Chores**
  * Updated Grafana link configuration for H200 Hera cluster
  * Modified run identifier format for parallelism tag generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-psap/performance-dashboard/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->