### PR TITLE
Add CPU dashboard, competitive analysis enhancements, and staging infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,7 @@ data/*.json
 !data/sample*
 !data/README.md
 dummy-no-git/
+gpt-oss-dynamo-llmd/
 
 # Log files
 *.log

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -17,9 +17,11 @@ COPY dashboard.py .
 COPY dashboard_styles.py .
 COPY mlperf_datacenter.py .
 COPY llmd_dashboard.py .
+COPY cpu_dashboard.py .
 COPY intelliconfig.py .
 COPY consolidated_dashboard.csv .
 COPY llmd-dashboard.csv .
+COPY cpu_dashboard.csv .
 
 # Copy all MLPerf data (version CSV files and dataset summaries)
 COPY mlperf-data/ ./mlperf-data/

--- a/cpu_dashboard.py
+++ b/cpu_dashboard.py
@@ -1,0 +1,1141 @@
+"""vLLM CPU Dashboard Module.
+
+This module provides functionality to load, process, and visualize
+vLLM CPU inference benchmark results across different CPU platforms,
+models, and configurations.
+"""
+
+import contextlib
+import io
+import logging
+import os
+import sys
+from typing import Literal, Optional
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import plotly.io as pio
+import streamlit as st
+
+# Set global Plotly template if not already set by main dashboard
+if "plotly_white_light" not in pio.templates:
+    _light_hover = go.layout.Template(
+        layout=go.Layout(
+            hoverlabel={
+                "bgcolor": "white",
+                "font_color": "#262730",
+                "bordercolor": "#d1d5db",
+            },
+        ),
+    )
+    pio.templates["plotly_white_light"] = pio.templates["plotly_white"]
+    pio.templates["plotly_white_light"].layout.update(_light_hover.layout)
+    pio.templates.default = "plotly_white_light"
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger(__name__)
+
+# S3 Configuration from environment variables
+S3_BUCKET = os.environ.get("S3_BUCKET")
+S3_KEY_CPU = os.environ.get("S3_KEY_CPU", "cpu_dashboard.csv")
+S3_REGION = os.environ.get("S3_REGION", "us-east-1")
+AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
+
+
+def _read_csv_from_s3(bucket: str, key: str, region: str = "us-east-1") -> pd.DataFrame:
+    """Read a CSV file from S3 bucket."""
+    try:
+        import boto3
+    except ImportError:
+        raise ImportError(
+            "boto3 is required for S3 access. Install with: pip install boto3"
+        )
+
+    session_kwargs = {"region_name": region}
+    if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+        session_kwargs["aws_access_key_id"] = AWS_ACCESS_KEY_ID
+        session_kwargs["aws_secret_access_key"] = AWS_SECRET_ACCESS_KEY
+
+    session = boto3.Session(**session_kwargs)
+    s3_client = session.client("s3")
+
+    response = s3_client.get_object(Bucket=bucket, Key=key)
+    csv_content = response["Body"].read().decode("utf-8")
+    return pd.read_csv(io.StringIO(csv_content))
+
+
+def _keep_expander_open(expander_key):
+    """Helper to keep an expander open after widget interaction."""
+    st.session_state[expander_key] = True
+
+
+def assign_profile(row):
+    """Assigns a profile label from the actual ISL/OSL values in the data."""
+    prompt_toks = int(row["prompt toks"])
+    output_toks = int(row["output toks"])
+    return f"{prompt_toks}/{output_toks}"
+
+
+# ---------------------------------------------------------------------------
+# Data Loading
+# ---------------------------------------------------------------------------
+
+
+@st.cache_data(ttl=300)
+def load_cpu_data(file_path: str) -> Optional[pd.DataFrame]:
+    """Load and preprocess vLLM CPU benchmark data from CSV file or S3.
+
+    Args:
+        file_path: Path to the CSV file to load (fallback).
+
+    Returns:
+        DataFrame with loaded and processed data, or None if error occurs.
+    """
+    try:
+        if S3_BUCKET:
+            try:
+                df = _read_csv_from_s3(S3_BUCKET, S3_KEY_CPU, S3_REGION)
+                logger.info(
+                    f"Successfully loaded CPU data from S3: s3://{S3_BUCKET}/{S3_KEY_CPU}"
+                )
+            except Exception as s3_error:
+                logger.warning(
+                    f"S3 load failed ({s3_error}), falling back to local file"
+                )
+                df = pd.read_csv(file_path)
+        else:
+            logger.info(f"Loading CPU data from local file: {file_path}")
+            df = pd.read_csv(file_path)
+
+        # Strip whitespace from string columns
+        for col in df.select_dtypes(include=["object"]).columns:
+            df[col] = df[col].str.strip()
+
+        # Convert numeric columns
+        numeric_cols = ["TP", "core_count", "omp_num_threads", "cpuset_mems"]
+        for col_name in numeric_cols:
+            if col_name in df.columns:
+                df[col_name] = pd.to_numeric(df[col_name], errors="coerce")
+
+        # Assign profile based on prompt/output tokens
+        if "prompt toks" in df.columns and "output toks" in df.columns:
+            df["profile"] = df.apply(assign_profile, axis=1)
+
+        # Calculate efficiency (output tokens/sec per core) where core_count > 0
+        if "output_tok/sec" in df.columns and "core_count" in df.columns:
+            cores = pd.to_numeric(df["core_count"], errors="coerce")
+            df["efficiency"] = np.where(cores > 0, df["output_tok/sec"] / cores, np.nan)
+
+        # Convert TTFT metrics from milliseconds to seconds
+        ttft_cols = [
+            "ttft_median",
+            "ttft_p95",
+            "ttft_p1",
+            "ttft_p99",
+            "ttft_p999",
+            "ttft_mean",
+        ]
+        for ttft_col in ttft_cols:
+            if ttft_col in df.columns:
+                df[f"{ttft_col}_s"] = df[ttft_col] / 1000
+
+        # Calculate error rate
+        if "successful_requests" in df.columns and "errored_requests" in df.columns:
+            total_requests = df["successful_requests"] + df["errored_requests"]
+            df["error_rate"] = (df["errored_requests"] / total_requests * 100).fillna(0)
+
+        return df
+    except FileNotFoundError:
+        st.error(f"Error: The data file was not found at '{file_path}'.")
+        return None
+    except Exception as e:
+        st.error(f"Error loading data from '{file_path}': {str(e)}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+def render_cpu_filters(df: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
+    """Render cascading filter UI for vLLM CPU dashboard.
+
+    Args:
+        df: CPU benchmark DataFrame
+
+    Returns:
+        Tuple of (filtered_df, filter_selections)
+    """
+    st.markdown("### Filter your data")
+
+    # Row 1: Platform, Workload (ISL/OSL), Version
+    filter_col1, filter_col2, filter_col3 = st.columns(3)
+
+    with filter_col1:
+        all_accelerators = sorted(df["accelerator"].unique().tolist())
+        default_accelerators = st.session_state.get(
+            "cpu_baseline_accelerators", all_accelerators
+        )
+        default_accelerators = [
+            a for a in default_accelerators if a in all_accelerators
+        ]
+        if not default_accelerators:
+            default_accelerators = all_accelerators
+
+        selected_accelerators = st.multiselect(
+            "1️⃣ Platform (CPU)",
+            options=all_accelerators,
+            default=default_accelerators,
+            key="cpu_filter_accelerator",
+        )
+        if not selected_accelerators:
+            selected_accelerators = all_accelerators
+
+    # Cascade: filter available workloads by selected platforms
+    acc_filtered = df[df["accelerator"].isin(selected_accelerators)]
+
+    with filter_col2:
+        all_profiles = sorted(acc_filtered["profile"].unique().tolist())
+        selected_profile = st.selectbox(
+            "2️⃣ Workload (ISL/OSL)",
+            options=all_profiles,
+            index=0,
+            key="cpu_filter_profile",
+        )
+
+    # Cascade: filter available versions by platform + workload
+    profile_filtered = acc_filtered[acc_filtered["profile"] == selected_profile]
+
+    with filter_col3:
+        all_versions = sorted(profile_filtered["version"].unique().tolist())
+        default_versions = st.session_state.get("cpu_baseline_versions", all_versions)
+        default_versions = [v for v in default_versions if v in all_versions]
+        if not default_versions:
+            default_versions = all_versions
+
+        selected_versions = st.multiselect(
+            "3️⃣ Version",
+            options=all_versions,
+            default=default_versions,
+            key="cpu_filter_version",
+        )
+        if not selected_versions:
+            selected_versions = all_versions
+
+    # Row 2: Model, Core Count, OMP Num Threads
+    ver_filtered = profile_filtered[profile_filtered["version"].isin(selected_versions)]
+
+    filter_col4, filter_col5, filter_col6 = st.columns(3)
+
+    with filter_col4:
+        all_models = sorted(ver_filtered["model"].unique().tolist())
+        selected_model = st.selectbox(
+            "4️⃣ Model",
+            options=all_models,
+            index=0,
+            key="cpu_filter_model",
+        )
+
+    model_filtered = ver_filtered[ver_filtered["model"] == selected_model]
+
+    with filter_col5:
+        if "core_count" in model_filtered.columns:
+            all_cores = sorted(
+                [int(c) for c in model_filtered["core_count"].dropna().unique()]
+            )
+            if all_cores:
+                selected_cores = st.multiselect(
+                    "5️⃣ Core Count",
+                    options=all_cores,
+                    default=all_cores,
+                    key="cpu_filter_cores",
+                )
+                if not selected_cores:
+                    selected_cores = all_cores
+            else:
+                selected_cores = None
+        else:
+            selected_cores = None
+
+    with filter_col6:
+        if "omp_num_threads" in model_filtered.columns:
+            all_omp = sorted(
+                [int(t) for t in model_filtered["omp_num_threads"].dropna().unique()]
+            )
+            if all_omp:
+                selected_omp = st.multiselect(
+                    "6️⃣ OMP Num Threads",
+                    options=all_omp,
+                    default=all_omp,
+                    key="cpu_filter_omp",
+                )
+                if not selected_omp:
+                    selected_omp = all_omp
+            else:
+                selected_omp = None
+        else:
+            selected_omp = None
+
+    # Apply all filters
+    mask = (
+        df["accelerator"].isin(selected_accelerators)
+        & (df["model"] == selected_model)
+        & df["version"].isin(selected_versions)
+        & (df["profile"] == selected_profile)
+    )
+
+    if selected_cores is not None:
+        mask = mask & (df["core_count"].isin(selected_cores) | df["core_count"].isna())
+
+    if selected_omp is not None:
+        mask = mask & (
+            df["omp_num_threads"].isin(selected_omp) | df["omp_num_threads"].isna()
+        )
+
+    filtered_df = df[mask].copy()
+
+    filter_selections = {
+        "accelerators": selected_accelerators,
+        "model": selected_model,
+        "versions": selected_versions,
+        "profile": selected_profile,
+        "cores": selected_cores,
+        "omp_threads": selected_omp,
+    }
+
+    return filtered_df, filter_selections
+
+
+# ---------------------------------------------------------------------------
+# Section: Performance Plots
+# ---------------------------------------------------------------------------
+
+
+def render_performance_plots_section(filtered_df, use_expander=True):
+    """Render performance plots section for vLLM CPU dashboard."""
+    if use_expander:
+        ctx = st.expander("📈 Performance Plots", expanded=False)
+    else:
+        ctx = contextlib.nullcontext()
+    with ctx:
+        if not use_expander:
+            st.subheader("📈 Performance Plots")
+        st.markdown(
+            "💡 **Tip:** Click on the full screen view (⛶) of any graph to get a detailed view."
+        )
+
+        if filtered_df.empty:
+            st.warning("No data available for selected filters.")
+            return
+
+        # Build run identifier for legend
+        filtered_df = filtered_df.copy()
+        filtered_df["model_short"] = filtered_df["model"].apply(
+            lambda x: x.split("/")[-1] if pd.notna(x) else "Unknown"
+        )
+
+        core_str = filtered_df["core_count"].apply(
+            lambda v: f"{int(v)}c" if pd.notna(v) and v > 0 else ""
+        )
+
+        # Include short uuid to distinguish multiple runs of the same config
+        uuid_short = filtered_df["uuid"].apply(lambda u: u[:8] if pd.notna(u) else "")
+        filtered_df["run_identifier"] = (
+            filtered_df["accelerator"]
+            + " | "
+            + filtered_df["model_short"]
+            + " | "
+            + filtered_df["version"]
+            + " | "
+            + core_str
+            + " | "
+            + uuid_short
+        )
+
+        col1, col2 = st.columns(2)
+        with col1:
+            x_axis_options = {
+                "Concurrency": "intended concurrency",
+                "Throughput (Output Tok/s)": "output_tok/sec",
+            }
+            x_axis_label = st.selectbox(
+                "Select X-Axis",
+                options=list(x_axis_options.keys()),
+                key="cpu_perf_plots_x_axis",
+            )
+            x_axis = x_axis_options[x_axis_label]
+
+        with col2:
+            y_axis_options = {
+                "Throughput (Output tokens/second generated)": "output_tok/sec",
+                "Efficiency (Output tokens/sec per core)": "efficiency",
+                "Inter-Token Latency P95 (Time between tokens, ms)": "itl_p95",
+                "Inter-Token Latency Mean (ms)": "itl_mean",
+                "Time to First Token P95 (Response start delay, s)": "ttft_p95_s",
+                "Time to First Token Mean (s)": "ttft_mean_s",
+                "Request Latency Median (Total request processing time, s)": "request_latency_median",
+                "Request Latency Max (s)": "request_latency_max",
+                "Time Per Output Token P95 (ms)": "tpot_p95",
+                "Time Per Output Token Mean (ms)": "tpot_mean",
+                "Total Throughput (Total tokens/second processed)": "total_tok/sec",
+                "Successful Requests": "successful_requests",
+                "Error Rate (% Failed requests)": "error_rate",
+            }
+            y_axis_label = st.selectbox(
+                "Select Y-Axis",
+                options=list(y_axis_options.keys()),
+                index=0,
+                key="cpu_perf_plots_y_axis",
+            )
+            y_axis = y_axis_options[y_axis_label]
+
+        # Build chart with explicit traces per config group
+        fig = go.Figure()
+        colors = px.colors.qualitative.Set2 + px.colors.qualitative.Plotly
+        grouped = filtered_df.groupby("run_identifier", sort=False)
+
+        # Sort groups by model then platform for consistent ordering
+        sorted_groups = sorted(grouped, key=lambda g: g[0])
+
+        for idx, (run_id, group_df) in enumerate(sorted_groups):
+            group_df = group_df.sort_values(x_axis)
+            fig.add_trace(
+                go.Scatter(
+                    x=group_df[x_axis],
+                    y=group_df[y_axis],
+                    name=run_id,
+                    mode="lines+markers",
+                    line={"color": colors[idx % len(colors)], "width": 2},
+                    marker={"size": 7},
+                    hovertemplate=(
+                        f"<b>{run_id}</b><br>"
+                        f"{x_axis_label}: %{{x:.2f}}<br>"
+                        f"{y_axis_label}: %{{y:.2f}}<br>"
+                        "<extra></extra>"
+                    ),
+                )
+            )
+
+        fig.update_layout(
+            title=f"{x_axis_label} vs. {y_axis_label}",
+            xaxis_title=x_axis_label,
+            yaxis_title=y_axis_label,
+            template="plotly_white_light",
+            height=600,
+            hovermode="closest",
+            legend_title_text="Run Details (Platform | Model | Version | Cores | UUID)",
+            legend={"font": {"size": 11}},
+        )
+        st.plotly_chart(fig, use_container_width=True, theme=None)
+
+        caption_col1, caption_col2 = st.columns([3, 1])
+        with caption_col2:
+            st.caption("📜 **Tip**: Scroll within the legend box to see all runs")
+
+
+# ---------------------------------------------------------------------------
+# Section: Compare Versions
+# ---------------------------------------------------------------------------
+
+
+def _compare_metric(data_v1, data_v2, metric_col, higher_is_better):
+    """Compare a metric between two version datasets at common concurrency points.
+
+    Returns:
+        (pct_diff, v1_better, v1_peak_conc, v2_peak_conc, is_similar)
+    """
+    v1_concs = set(data_v1["intended concurrency"].dropna().unique())
+    v2_concs = set(data_v2["intended concurrency"].dropna().unique())
+    common = v1_concs.intersection(v2_concs)
+
+    if not common:
+        return None, None, None, None, None
+
+    v1_common = data_v1[data_v1["intended concurrency"].isin(common)]
+    v2_common = data_v2[data_v2["intended concurrency"].isin(common)]
+
+    v1_vals = v1_common[metric_col].dropna()
+    v2_vals = v2_common[metric_col].dropna()
+
+    if v1_vals.empty or v2_vals.empty:
+        return None, None, None, None, None
+
+    if higher_is_better:
+        v1_val = v1_vals.max()
+        v2_val = v2_vals.max()
+        v1_peak_conc = float(v1_common.loc[v1_vals.idxmax(), "intended concurrency"])
+        v2_peak_conc = float(v2_common.loc[v2_vals.idxmax(), "intended concurrency"])
+    else:
+        v1_val = v1_vals.min()
+        v2_val = v2_vals.min()
+        v1_peak_conc = float(v1_common.loc[v1_vals.idxmin(), "intended concurrency"])
+        v2_peak_conc = float(v2_common.loc[v2_vals.idxmin(), "intended concurrency"])
+
+    if v2_val == 0:
+        return None, None, None, None, None
+
+    pct_diff = ((v1_val - v2_val) / v2_val) * 100
+    v1_better = pct_diff > 0 if higher_is_better else pct_diff < 0
+
+    return pct_diff, v1_better, v1_peak_conc, v2_peak_conc, abs(pct_diff) < 5
+
+
+@st.fragment
+def render_compare_versions_section(df, use_expander=True):
+    """Compare two vLLM CPU versions across multiple metrics."""
+    if use_expander:
+        ctx = st.expander("⚖️ Compare Versions", expanded=False)
+    else:
+        ctx = contextlib.nullcontext()
+    with ctx:
+        if not use_expander:
+            st.subheader("⚖️ Compare Versions")
+        st.markdown(
+            "💡 **Compare performance between two vLLM versions across all models and metrics.**"
+        )
+
+        available_versions = sorted(df["version"].unique().tolist())
+
+        if len(available_versions) < 2:
+            st.warning("⚠️ Need at least 2 versions in the data to compare.")
+            return
+
+        col1, col2, col3, col4 = st.columns(4)
+
+        with col1:
+            version_1 = st.selectbox(
+                "Version 1 (Baseline)",
+                options=available_versions,
+                index=0,
+                key="cpu_compare_v1",
+            )
+
+        with col2:
+            version_2_options = [v for v in available_versions if v != version_1]
+            version_2 = (
+                st.selectbox(
+                    "Version 2 (Comparison)",
+                    options=version_2_options,
+                    index=0 if version_2_options else None,
+                    key="cpu_compare_v2",
+                )
+                if version_2_options
+                else None
+            )
+
+        if not version_2:
+            st.warning("⚠️ Please select a second version to compare.")
+            return
+
+        # Only show platforms that exist in BOTH selected versions
+        v1_accelerators = set(df[df["version"] == version_1]["accelerator"].unique())
+        v2_accelerators = set(df[df["version"] == version_2]["accelerator"].unique())
+        common_accelerators = sorted(v1_accelerators.intersection(v2_accelerators))
+
+        if not common_accelerators:
+            st.warning(
+                f"⚠️ No common platforms found between {version_1} and {version_2}."
+            )
+            return
+
+        with col3:
+            selected_accelerator = st.selectbox(
+                "Platform (CPU)",
+                options=common_accelerators,
+                index=0,
+                key="cpu_compare_accelerator",
+            )
+
+        # Only show profiles that exist for the selected platform in BOTH versions
+        v1_profiles = set(
+            df[
+                (df["version"] == version_1)
+                & (df["accelerator"] == selected_accelerator)
+            ]["profile"].unique()
+        )
+        v2_profiles = set(
+            df[
+                (df["version"] == version_2)
+                & (df["accelerator"] == selected_accelerator)
+            ]["profile"].unique()
+        )
+        common_profiles = sorted(v1_profiles.intersection(v2_profiles))
+
+        if not common_profiles:
+            st.warning(
+                f"⚠️ No common workloads found for {selected_accelerator} "
+                f"between {version_1} and {version_2}."
+            )
+            return
+
+        with col4:
+            selected_profile = st.selectbox(
+                "Workload (ISL/OSL)",
+                options=common_profiles,
+                index=0,
+                key="cpu_compare_profile",
+            )
+
+        # Filter data for each version
+        mask_v1 = (
+            (df["version"] == version_1)
+            & (df["accelerator"] == selected_accelerator)
+            & (df["profile"] == selected_profile)
+        )
+        mask_v2 = (
+            (df["version"] == version_2)
+            & (df["accelerator"] == selected_accelerator)
+            & (df["profile"] == selected_profile)
+        )
+        df_v1 = df[mask_v1].copy()
+        df_v2 = df[mask_v2].copy()
+
+        if df_v1.empty or df_v2.empty:
+            st.warning(
+                "⚠️ No data available for the selected combination. "
+                "Try different platform or workload settings."
+            )
+            return
+
+        # Find common models
+        v1_models = set(df_v1["model"].unique())
+        v2_models = set(df_v2["model"].unique())
+        common_models = sorted(v1_models.intersection(v2_models))
+
+        if not common_models:
+            st.warning(
+                f"⚠️ No common models found between {version_1} and {version_2} "
+                f"for {selected_accelerator} with workload {selected_profile}."
+            )
+            return
+
+        # Metrics to compare
+        metrics = [
+            ("output_tok/sec", "Output Tok/s (Peak)", True),
+            ("ttft_p95", "TTFT P95 (ms)", False),
+            ("tpot_p95", "TPOT P95 (ms)", False),
+            ("itl_p95", "ITL P95 (ms)", False),
+            ("request_latency_median", "Request Latency Median (s)", False),
+        ]
+
+        results = []
+        for model in common_models:
+            model_v1 = df_v1[df_v1["model"] == model]
+            model_v2 = df_v2[df_v2["model"] == model]
+
+            model_short = model.split("/")[-1] if "/" in model else model
+            row = {"Model": model_short}
+
+            for metric_col, metric_label, higher_is_better in metrics:
+                if metric_col not in model_v1.columns:
+                    continue
+                result = _compare_metric(
+                    model_v1, model_v2, metric_col, higher_is_better
+                )
+                pct_diff, v1_better, _, _, is_similar = result
+
+                if pct_diff is not None:
+                    if is_similar:
+                        row[metric_label] = f"🟡 ~{abs(pct_diff):.1f}% (similar)"
+                    elif v1_better:
+                        row[metric_label] = (
+                            f"🟢 +{abs(pct_diff):.1f}% ({version_1} better)"
+                        )
+                    else:
+                        row[metric_label] = (
+                            f"🔴 -{abs(pct_diff):.1f}% ({version_2} better)"
+                        )
+                else:
+                    row[metric_label] = "N/A"
+
+            results.append(row)
+
+        if results:
+            st.markdown(
+                f"**Comparison: {version_1} vs {version_2}** on "
+                f"**{selected_accelerator}** with workload **{selected_profile}**"
+            )
+            results_df = pd.DataFrame(results)
+            st.dataframe(results_df, use_container_width=True, hide_index=True)
+
+            st.caption(
+                f"Legend: 🟢 {version_1} performs better than {version_2} | "
+                f"🔴 {version_1} performs worse than {version_2} | "
+                f"🟡 Similar Performance (< 5% difference)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Section: Runtime Server Configs
+# ---------------------------------------------------------------------------
+
+
+def render_runtime_configs_section(filtered_df, use_expander=True):
+    """Render runtime server configs section for vLLM CPU dashboard."""
+    if use_expander:
+        ctx = st.expander("⚙️ Runtime Server Configs", expanded=False)
+    else:
+        ctx = contextlib.nullcontext()
+    with ctx:
+        if not use_expander:
+            st.subheader("⚙️ Runtime Server Configs")
+
+        if "runtime_args" not in filtered_df.columns:
+            st.info("No runtime configuration data available.")
+            return
+
+        st.markdown("**Runtime configurations for your current filter selections:**")
+        st.info(
+            "📊 **Column Legend**: Shows the server runtime arguments used for each "
+            "Platform + Model + Version + Core configuration that matches your current filters."
+        )
+
+        subset_cols = ["model", "accelerator", "version", "profile"]
+        extra_cols = []
+        if "core_count" in filtered_df.columns:
+            subset_cols.append("core_count")
+            extra_cols.append("core_count")
+        if "omp_num_threads" in filtered_df.columns:
+            subset_cols.append("omp_num_threads")
+            extra_cols.append("omp_num_threads")
+        if "cpuset_cpus" in filtered_df.columns:
+            subset_cols.append("cpuset_cpus")
+            extra_cols.append("cpuset_cpus")
+
+        unique_configs = filtered_df.drop_duplicates(subset=subset_cols)
+
+        if unique_configs.empty:
+            st.info("No configurations found for current filters.")
+            return
+
+        display_cols = ["model", "accelerator", "version"]
+        if "runtime_args" in unique_configs.columns:
+            display_cols.append("runtime_args")
+        display_cols.append("profile")
+        display_cols += extra_cols
+        if "image_tag" in unique_configs.columns:
+            display_cols.append("image_tag")
+        if "guidellm_version" in unique_configs.columns:
+            display_cols.append("guidellm_version")
+
+        configs_df = unique_configs[display_cols].copy()
+        configs_df.reset_index(drop=True, inplace=True)
+        configs_df.insert(0, "Config #", range(1, len(configs_df) + 1))
+
+        rename_map = {
+            "model": "Model",
+            "accelerator": "Platform",
+            "version": "Version",
+            "profile": "Workload (ISL/OSL)",
+            "core_count": "Core Count",
+            "omp_num_threads": "OMP Threads",
+            "cpuset_cpus": "CPU Set",
+            "runtime_args": "Runtime Arguments",
+            "image_tag": "Image Tag",
+            "guidellm_version": "GuideLLM Version",
+        }
+        configs_df.rename(columns=rename_map, inplace=True)
+
+        # Format numeric columns
+        for col in ["Core Count", "OMP Threads"]:
+            if col in configs_df.columns:
+                configs_df[col] = configs_df[col].apply(
+                    lambda v: "N/A" if pd.isna(v) else str(int(v))
+                )
+
+        row_height = 40
+        header_height = 40
+        padding = 20
+        dynamic_height = min(
+            max(len(configs_df) * row_height + header_height + padding, 150),
+            600,
+        )
+
+        st.dataframe(
+            configs_df,
+            use_container_width=True,
+            hide_index=True,
+            height=dynamic_height,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section: Filtered Data
+# ---------------------------------------------------------------------------
+
+
+def render_filtered_data_section(filtered_df, use_expander=True):
+    """Render filtered data table section for vLLM CPU dashboard."""
+    if use_expander:
+        ctx = st.expander("📄 Filtered Data", expanded=False)
+    else:
+        ctx = contextlib.nullcontext()
+    with ctx:
+        if not use_expander:
+            st.subheader("📄 Filtered Data")
+
+        if filtered_df.empty:
+            st.warning("No data available for selected filters.")
+            return
+
+        st.info(
+            "💡 **Tips**: Hover over column headers to see detailed descriptions of each field."
+        )
+        display_df = filtered_df.copy()
+        display_df.reset_index(drop=True, inplace=True)
+        display_df.insert(0, "Row #", range(1, len(display_df) + 1))
+
+        column_config = {
+            "Row #": st.column_config.NumberColumn("Row #", pinned=True),
+            "run": st.column_config.TextColumn(
+                "run",
+                help="Unique identifier combining platform, model, and configuration",
+                pinned=True,
+            ),
+            "accelerator": st.column_config.TextColumn(
+                "accelerator",
+                help="CPU platform type (e.g., EPYC-NO-SMT, Xeon-NO-SMT)",
+            ),
+            "model": st.column_config.TextColumn(
+                "model", help="Full path/name of the LLM model being benchmarked"
+            ),
+            "version": st.column_config.TextColumn(
+                "version",
+                help="vLLM version (e.g., vLLM-0.18.0+rhaiv.5)",
+                pinned=True,
+            ),
+            "prompt toks": st.column_config.NumberColumn(
+                "prompt toks",
+                help="Target number of prompt (input) tokens in the benchmark",
+            ),
+            "output toks": st.column_config.NumberColumn(
+                "output toks",
+                help="Target number of output tokens to generate in the benchmark",
+            ),
+            "intended concurrency": st.column_config.NumberColumn(
+                "intended concurrency",
+                help="Target concurrency level - number of parallel requests sent to the server",
+                pinned=True,
+            ),
+            "measured concurrency": st.column_config.NumberColumn(
+                "measured concurrency",
+                help="Actual concurrency level achieved during the benchmark run",
+                format="%.2f",
+            ),
+            "output_tok/sec": st.column_config.NumberColumn(
+                "output_tok/sec",
+                help="Output tokens per second - key throughput metric (higher is better)",
+                format="%.2f",
+            ),
+            "total_tok/sec": st.column_config.NumberColumn(
+                "total_tok/sec",
+                help="Total tokens per second (input + output)",
+                format="%.2f",
+            ),
+            "ttft_median": st.column_config.NumberColumn(
+                "ttft_median",
+                help="Time to First Token - Median (ms)",
+                format="%.2f",
+            ),
+            "ttft_p95": st.column_config.NumberColumn(
+                "ttft_p95",
+                help="Time to First Token - 95th percentile (ms)",
+                format="%.2f",
+            ),
+            "tpot_median": st.column_config.NumberColumn(
+                "tpot_median",
+                help="Time Per Output Token - Median (ms)",
+                format="%.2f",
+            ),
+            "tpot_p95": st.column_config.NumberColumn(
+                "tpot_p95",
+                help="Time Per Output Token - 95th percentile (ms)",
+                format="%.2f",
+            ),
+            "itl_median": st.column_config.NumberColumn(
+                "itl_median",
+                help="Inter-Token Latency - Median (ms)",
+                format="%.2f",
+            ),
+            "itl_p95": st.column_config.NumberColumn(
+                "itl_p95",
+                help="Inter-Token Latency - 95th percentile (ms)",
+                format="%.2f",
+            ),
+            "core_count": st.column_config.NumberColumn(
+                "core_count",
+                help="Number of CPU cores used for inference",
+            ),
+            "cpuset_cpus": st.column_config.TextColumn(
+                "cpuset_cpus",
+                help="CPU core pinning configuration",
+            ),
+            "omp_num_threads": st.column_config.NumberColumn(
+                "omp_num_threads",
+                help="OpenMP thread count configuration",
+            ),
+        }
+
+        row_height = 40
+        header_height = 40
+        padding = 20
+        dynamic_height = min(
+            max(len(display_df) * row_height + header_height + padding, 200),
+            800,
+        )
+
+        st.dataframe(
+            display_df,
+            use_container_width=True,
+            hide_index=True,
+            height=dynamic_height,
+            column_config=column_config,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main Entry Point
+# ---------------------------------------------------------------------------
+
+
+def render_cpu_dashboard(cpu_csv_path: str):
+    """Render the vLLM CPU benchmark dashboard.
+
+    Args:
+        cpu_csv_path: Path to the CPU dashboard CSV data file
+    """
+    # Load data
+    df = load_cpu_data(cpu_csv_path)
+
+    if df is None or df.empty:
+        st.error("No data available. Please check the data file.")
+        return
+
+    # Section navigation
+    section_list = [
+        "📈 Performance Plots",
+        "⚖️ Compare Versions",
+        "⚙️ Runtime Server Configs",
+        "📄 Filtered Data",
+    ]
+
+    SECTION_GROUPS = [
+        (
+            "Performance Analysis",
+            [
+                "📈 Performance Plots",
+                "⚖️ Compare Versions",
+            ],
+        ),
+        (
+            "Tools",
+            [
+                "⚙️ Runtime Server Configs",
+                "📄 Filtered Data",
+            ],
+        ),
+    ]
+
+    CPU_SECTION_SLUG_MAP = {
+        "📈 Performance Plots": "performance_plots",
+        "⚖️ Compare Versions": "compare_versions",
+        "⚙️ Runtime Server Configs": "runtime_configs",
+        "📄 Filtered Data": "filtered_data",
+    }
+    CPU_SLUG_TO_SECTION = {v: k for k, v in CPU_SECTION_SLUG_MAP.items()}
+
+    # Restore section from URL on first load
+    if "cpu_url_loaded" not in st.session_state:
+        st.session_state.cpu_url_loaded = True
+        if "section" in st.query_params:
+            slug = st.query_params["section"]
+            if slug in CPU_SLUG_TO_SECTION:
+                st.session_state.cpu_active_section = CPU_SLUG_TO_SECTION[slug]
+
+    current_section = st.session_state.get("cpu_active_section", section_list[0])
+    if current_section not in section_list:
+        current_section = section_list[0]
+    st.session_state.cpu_active_section = current_section
+
+    CPU_SECTIONS_WITHOUT_GLOBAL_FILTERS = {
+        "⚖️ Compare Versions",
+    }
+    _show_global_filters = current_section not in CPU_SECTIONS_WITHOUT_GLOBAL_FILTERS
+
+    if _show_global_filters:
+        filtered_df, filter_selections = render_cpu_filters(df)
+        st.markdown("---")
+    else:
+        filtered_df = df.copy()
+        filter_selections = {}
+
+    # Sidebar navigation
+    with st.sidebar:
+        for group_name, group_sections in SECTION_GROUPS:
+            visible = [s for s in group_sections if s in section_list]
+            if not visible:
+                continue
+            st.markdown(
+                f'<p class="nav-group-header">{group_name}</p>',
+                unsafe_allow_html=True,
+            )
+            for section_name in visible:
+                is_active = section_name == current_section
+                btn_type: Literal["primary", "secondary"] = (
+                    "primary" if is_active else "secondary"
+                )
+                if st.button(
+                    section_name,
+                    key=f"cpu_nav_{section_name}",
+                    use_container_width=True,
+                    type=btn_type,
+                ):
+                    st.session_state.cpu_active_section = section_name
+                    st.rerun()
+
+    # Render selected section
+    if not filtered_df.empty:
+
+        def _render_selected_section(sel):
+            if sel == "📈 Performance Plots":
+                render_performance_plots_section(filtered_df, use_expander=False)
+            elif sel == "⚖️ Compare Versions":
+                render_compare_versions_section(df, use_expander=False)
+            elif sel == "⚙️ Runtime Server Configs":
+                render_runtime_configs_section(filtered_df, use_expander=False)
+            elif sel == "📄 Filtered Data":
+                render_filtered_data_section(filtered_df, use_expander=False)
+
+        _render_selected_section(current_section)
+
+    else:
+        st.warning(
+            "❌ **No data matches your current filter settings.** Please adjust the filters."
+        )
+
+    # Sync section to URL
+    with contextlib.suppress(Exception):
+        desired_params: dict[str, str] = {}
+        if "view" in st.query_params:
+            desired_params["view"] = st.query_params["view"]
+
+        section_slug = CPU_SECTION_SLUG_MAP.get(current_section)
+        if section_slug:
+            desired_params["section"] = section_slug
+
+        if _show_global_filters:
+            sel_acc = filter_selections.get("accelerators", [])
+            sel_mod = filter_selections.get("model", "")
+            sel_ver = filter_selections.get("versions", [])
+
+            if sel_acc:
+                desired_params["accelerators"] = ",".join(sel_acc)
+            if sel_mod:
+                desired_params["model"] = sel_mod
+            if sel_ver:
+                desired_params["versions"] = ",".join(sel_ver)
+
+        st.query_params.update(desired_params)
+
+    # Click anywhere on main area to collapse sidebar + scroll to top + hamburger icon
+    import streamlit.components.v1 as _stc
+
+    _stc.html(
+        f"""
+<script>
+(function() {{
+    var doc = parent.document;
+
+    // --- Scroll to top on section change ---
+    var currentSection = "{current_section}";
+    if (doc._lastSection && doc._lastSection !== currentSection) {{
+        var main = doc.querySelector('[data-testid="stMain"]');
+        if (main) main.scrollTop = 0;
+        var sc = doc.querySelector('.main');
+        if (sc) sc.scrollTop = 0;
+        parent.window.scrollTo(0, 0);
+    }}
+    doc._lastSection = currentSection;
+
+    // --- Click-to-close sidebar ---
+    if (doc._sidebarClickClose) {{
+        doc.removeEventListener('click', doc._sidebarClickClose);
+    }}
+    if (doc._clickCloseTimeout) {{
+        clearTimeout(doc._clickCloseTimeout);
+    }}
+
+    doc._sidebarClickClose = function(e) {{
+        var sb = doc.querySelector('[data-testid="stSidebar"]');
+        if (!sb || sb.getAttribute('aria-expanded') !== 'true') return;
+        var main = doc.querySelector('[data-testid="stMain"]');
+        if (!main || !main.contains(e.target)) return;
+        setTimeout(function() {{
+            var sb2 = doc.querySelector('[data-testid="stSidebar"]');
+            if (!sb2 || sb2.getAttribute('aria-expanded') !== 'true') return;
+            var closeBtn = sb2.querySelector('[data-testid="stSidebarHeader"] button')
+                        || sb2.querySelector('button[kind="headerNoPadding"]')
+                        || sb2.querySelector('button[kind="header"]');
+            if (closeBtn) closeBtn.click();
+        }}, 0);
+    }};
+
+    var clickDelay = doc._clickCloseInitialized ? 0 : 1500;
+    doc._clickCloseInitialized = true;
+    doc._clickCloseTimeout = setTimeout(function() {{
+        doc.addEventListener('click', doc._sidebarClickClose);
+    }}, clickDelay);
+
+    // --- Hamburger icon replacement ---
+    if (doc._hamburgerInterval) clearInterval(doc._hamburgerInterval);
+
+    function scan() {{
+        var sb = doc.querySelector('[data-testid="stSidebar"]');
+        if (sb) {{
+            var hdr = sb.querySelector('[data-testid="stSidebarHeader"] button')
+                   || sb.querySelector('button[kind="headerNoPadding"]')
+                   || sb.querySelector('button[kind="header"]');
+            if (hdr) {{
+                hdr.classList.add('hamburger-btn');
+                hdr.setAttribute('data-tooltip', 'Collapse sidebar');
+            }}
+        }}
+        var sidebarOpen = sb && sb.getAttribute('aria-expanded') === 'true';
+        if (!sidebarOpen) {{
+            var header = doc.querySelector('[data-testid="stHeader"]');
+            if (header) {{
+                var firstBtn = header.querySelector('button');
+                if (firstBtn) {{
+                    firstBtn.classList.add('hamburger-btn');
+                    firstBtn.setAttribute('data-tooltip', 'Expand sidebar');
+                    if (!firstBtn.classList.contains('hamburger-pulse')) {{
+                        firstBtn.classList.add('hamburger-pulse');
+                    }}
+                }}
+            }}
+        }}
+        // Remove pulse when sidebar is open
+        if (sidebarOpen && sb) {{
+            var hdrBtn = sb.querySelector('[data-testid="stSidebarHeader"] button')
+                      || sb.querySelector('button[kind="headerNoPadding"]')
+                      || sb.querySelector('button[kind="header"]');
+            if (hdrBtn) hdrBtn.classList.remove('hamburger-pulse');
+        }}
+    }}
+
+    scan();
+    doc._hamburgerInterval = setInterval(scan, 500);
+}})();
+</script>
+""",
+        height=0,
+    )

--- a/dashboard.py
+++ b/dashboard.py
@@ -407,6 +407,42 @@ def compare_two_datasets(data_a, data_b, metric_config, user_conc_set):
     return pct_diff, a_better, a_peak_conc, b_peak_conc, abs(pct_diff) < 5
 
 
+def _resolve_baseline_df(h200_df, baseline, fallback_version, profile_full):
+    """Build a baseline DataFrame using the preferred (fallback) version per model.
+
+    For each model, rows from ``fallback_version`` are used when available;
+    otherwise rows from ``baseline`` are used.  When the preferred version has
+    NaN TP for a model that has a known TP in the base version, the base TP is
+    carried over so downstream (model, TP) matching still works.
+    """
+    preferred = h200_df[
+        (h200_df["version"] == fallback_version) & (h200_df["profile"] == profile_full)
+    ].copy()
+    base = h200_df[
+        (h200_df["version"] == baseline) & (h200_df["profile"] == profile_full)
+    ]
+    if preferred.empty:
+        return base.copy()
+    if base.empty:
+        return preferred.copy()
+
+    base_tp_map = (
+        base.dropna(subset=["TP"])
+        .drop_duplicates(subset=["model"])
+        .set_index("model")["TP"]
+        .to_dict()
+    )
+    nan_tp_mask = preferred["TP"].isna()
+    if nan_tp_mask.any():
+        preferred.loc[nan_tp_mask, "TP"] = preferred.loc[nan_tp_mask, "model"].map(
+            base_tp_map
+        )
+
+    preferred_models = set(preferred["model"].unique())
+    fallback_rows = base[~base["model"].isin(preferred_models)]
+    return pd.concat([preferred, fallback_rows], ignore_index=True)
+
+
 def assign_profile_vectorized(df):
     """Assigns human-readable profile names based on token counts (vectorized)."""
     prompt = df["prompt toks"]
@@ -1097,6 +1133,59 @@ def _hm_cell(pct, higher_is_better):
 
 CA_CONFIGURATIONS = [
     {
+        "label": "vLLM-0.21.0",
+        "description": (
+            "Performance comparison of **vLLM-0.21.0** "
+            "against **sglang-0.5.11** and **TRT-LLM** (1.3.0rc13, "
+            "gpt-oss-dev) on **NVIDIA H200**."
+        ),
+        "groups": [
+            {
+                "title": "vLLM vs SGLang",
+                "description": (
+                    "How **vLLM-0.21.0** compares to **sglang-0.5.11** "
+                    "on **NVIDIA H200**."
+                ),
+                "baselines": ["vLLM-0.21.0"],
+                "baseline_fallback": {
+                    "vLLM-0.21.0": "vLLM-0.21.0-competitive",
+                },
+                "competitors": ["sglang-0.5.11"],
+            },
+            {
+                "title": "vLLM vs TRT-LLM",
+                "description": (
+                    "How **vLLM-0.21.0** compares to **TRT-LLM** variants "
+                    "on **NVIDIA H200**."
+                ),
+                "baselines": ["vLLM-0.21.0"],
+                "baseline_fallback": {
+                    "vLLM-0.21.0": "vLLM-0.21.0-competitive",
+                },
+                "competitors": ["TRT-LLM-1.3.0rc13", "TRT-LLM-gpt-oss-dev"],
+            },
+            {
+                "title": "vLLM vs SGLang vs TRT-LLM (Common Models)",
+                "description": (
+                    "Three-way comparison of **vLLM-0.21.0** vs "
+                    "**sglang-0.5.11** vs **TRT-LLM** on models "
+                    "common to all three frameworks on **NVIDIA H200**. "
+                    "TRT-LLM uses 1.3.0rc13 for most models and "
+                    "gpt-oss-dev for gpt-oss-120b."
+                ),
+                "baselines": ["vLLM-0.21.0"],
+                "baseline_fallback": {
+                    "vLLM-0.21.0": "vLLM-0.21.0-competitive",
+                },
+                "competitors": ["sglang-0.5.11", "TRT-LLM"],
+                "competitor_versions": {
+                    "TRT-LLM": ["TRT-LLM-1.3.0rc13", "TRT-LLM-gpt-oss-dev"],
+                },
+                "three_way": True,
+            },
+        ],
+    },
+    {
         "label": "RHAIIS-3.4-EA2",
         "description": (
             "Performance comparison of **RHAIIS-3.4-EA2** "
@@ -1159,6 +1248,408 @@ CA_CONFIGURATIONS = [
         ],
     },
 ]
+
+
+def _render_ca_scorecard(score_placeholder, group_scores):
+    """Render the competitive analysis scorecard showing win/loss/similar counts.
+
+    Cards are clickable (``<details>``): clicking reveals a per-model
+    breakdown of wins, losses, and similar results.
+    """
+    if not group_scores:
+        return
+    with score_placeholder:
+        cols = st.columns(len(group_scores))
+        for col, (bl, comp_dict) in zip(cols, group_scores.items()):
+            all_w = sum(v[0] for v in comp_dict.values())
+            all_l = sum(v[1] for v in comp_dict.values())
+            all_s = sum(v[2] for v in comp_dict.values())
+            all_decisive = all_w + all_l
+            overall_wr = (all_w / all_decisive * 100) if all_decisive > 0 else None
+            hue = "green" if all_l == 0 else ("yellow" if all_w > all_l else "red")
+
+            competitor_rows = ""
+            for comp, score_entry in comp_dict.items():
+                cw, cl, cs = score_entry[0], score_entry[1], score_entry[2]
+                model_details = score_entry[3] if len(score_entry) > 3 else []
+                c_decisive = cw + cl
+                cwr = (cw / c_decisive * 100) if c_decisive > 0 else None
+                if cwr is None:
+                    wr_cls = "val-amber"
+                    wr_text = "—"
+                else:
+                    wr_cls = (
+                        "val-green"
+                        if cwr >= 60
+                        else ("val-amber" if cwr >= 40 else "val-red")
+                    )
+                    wr_text = f"{cwr:.0f}%"
+
+                models_by_name = {}
+                for md in model_details:
+                    name = md["model"]
+                    if name not in models_by_name:
+                        models_by_name[name] = {}
+                    models_by_name[name][md["profile"]] = md["verdict"]
+
+                profile_order = ["1k/1k", "8k/1k"]
+                detail_lines = ""
+                for name, prof_verdicts in sorted(models_by_name.items()):
+                    profile_cells = ""
+                    for p in profile_order:
+                        v = prof_verdicts.get(p)
+                        if v is None:
+                            profile_cells += (
+                                "<td style='padding:2px 8px;text-align:center;'>—</td>"
+                            )
+                        else:
+                            icon = {"win": "🟢", "loss": "🔴", "similar": "🟡"}[v]
+                            profile_cells += (
+                                f"<td style='padding:2px 8px;text-align:center;'>"
+                                f"{icon}</td>"
+                            )
+                    detail_lines += (
+                        f"<tr>"
+                        f"<td style='padding:2px 6px;'>{name}</td>"
+                        f"{profile_cells}"
+                        f"</tr>"
+                    )
+
+                detail_table = ""
+                if detail_lines:
+                    header_cells = "".join(
+                        f"<th style='padding:2px 8px;text-align:center;'>{p}</th>"
+                        for p in profile_order
+                    )
+                    detail_table = (
+                        f"<div style='margin-top:0.5rem;font-size:0.85rem;'>"
+                        f"<table style='width:100%;border-collapse:collapse;'>"
+                        f"<tr style='border-bottom:1px solid rgba(0,0,0,0.15);'>"
+                        f"<th style='padding:2px 6px;text-align:left;'>Model</th>"
+                        f"{header_cells}"
+                        f"</tr>"
+                        f"{detail_lines}</table></div>"
+                    )
+
+                competitor_rows += f"""<div class="vllm-stat-row" style="margin-top:0.5rem;">
+<div class="vllm-stat" style="flex:2;"><div class="vllm-stat-label" style="font-size:1rem;">vs {comp}</div></div>
+<div class="vllm-stat"><div class="vllm-stat-label">Win Rate</div><div class="vllm-stat-value {wr_cls}">{wr_text}</div></div>
+<div class="vllm-stat"><div class="vllm-stat-label">Wins</div><div class="vllm-stat-value val-green">{cw}</div></div>
+<div class="vllm-stat"><div class="vllm-stat-label">Losses</div><div class="vllm-stat-value val-red">{cl}</div></div>
+<div class="vllm-stat"><div class="vllm-stat-label">Similar</div><div class="vllm-stat-value val-amber">{cs}</div></div>
+</div>{detail_table}"""
+
+            wr_cls = (
+                "val-amber"
+                if overall_wr is None
+                else ("val-green" if overall_wr >= 60 else "val-red")
+            )
+            wr_text = "—" if overall_wr is None else f"{overall_wr:.0f}%"
+
+            with col:
+                st.markdown(
+                    f"""<div class="vllm-scorecard vllm-hue-{hue}">
+<details><summary style="cursor:pointer;list-style:none;">
+<div class="vllm-scorecard-title">{bl} vs {" / ".join(comp_dict.keys())}
+<span style="float:right;font-size:0.8rem;opacity:0.6;">▼ click for details</span>
+</div>
+<div class="vllm-stat-row">
+<div class="vllm-stat">
+<div class="vllm-stat-label">Overall Win Rate</div>
+<div class="vllm-stat-value {wr_cls}">{wr_text}</div>
+</div>
+<div class="vllm-stat">
+<div class="vllm-stat-label">Model Wins</div>
+<div class="vllm-stat-value val-green">{all_w}</div>
+</div>
+<div class="vllm-stat">
+<div class="vllm-stat-label">Model Losses</div>
+<div class="vllm-stat-value val-red">{all_l}</div>
+</div>
+<div class="vllm-stat">
+<div class="vllm-stat-label">Similar</div>
+<div class="vllm-stat-value val-amber">{all_s}</div>
+</div>
+</div>
+</summary>
+<hr style="margin:0.6rem 0;border:none;border-top:1px solid rgba(0,0,0,0.1);">
+{competitor_rows}
+<div style="margin-top:0.6rem;font-size:0.8rem;opacity:0.7;">🟢 {bl} wins majority of metrics &nbsp;|&nbsp; 🔴 {bl} loses majority of metrics &nbsp;|&nbsp; 🟡 Similar (tied or &lt;5% diff)</div>
+</details>
+</div>""",
+                    unsafe_allow_html=True,
+                )
+
+
+def _render_three_way_comparison(
+    h200_df,
+    group,
+    baseline_fallback,
+    profiles,
+    metrics_config,
+    column_config,
+    score_placeholder,
+    group_scores,
+):
+    """Render a side-by-side table comparing baseline against all competitors at once.
+
+    Only models common to every version (baseline + all competitors) are shown.
+    """
+    baseline = group["baselines"][0]
+    competitors = group["competitors"]
+    fallback_ver = baseline_fallback.get(baseline)
+    competitor_versions = group.get("competitor_versions", {})
+
+    profile_tabs_data = {}
+
+    for profile_full, profile_short in profiles:
+        if fallback_ver:
+            df_base = _resolve_baseline_df(
+                h200_df, baseline, fallback_ver, profile_full
+            )
+        else:
+            df_base = h200_df[
+                (h200_df["version"] == baseline) & (h200_df["profile"] == profile_full)
+            ].copy()
+
+        comp_dfs = {}
+        for comp in competitors:
+            versions_list = competitor_versions.get(comp)
+            if versions_list:
+                parts = [
+                    h200_df[
+                        (h200_df["version"] == v) & (h200_df["profile"] == profile_full)
+                    ]
+                    for v in versions_list
+                ]
+                merged = pd.concat(parts, ignore_index=True)
+                seen_models = set()
+                deduped_parts = []
+                for v in versions_list:
+                    part = merged[merged["version"] == v]
+                    new_rows = part[~part["model"].isin(seen_models)]
+                    deduped_parts.append(new_rows)
+                    seen_models.update(new_rows["model"].unique())
+                comp_dfs[comp] = pd.concat(deduped_parts, ignore_index=True)
+            else:
+                comp_dfs[comp] = h200_df[
+                    (h200_df["version"] == comp) & (h200_df["profile"] == profile_full)
+                ].copy()
+
+        if df_base.empty or any(cdf.empty for cdf in comp_dfs.values()):
+            continue
+
+        base_mt = set(zip(df_base["model"].tolist(), df_base["TP"].tolist()))
+        common_mt = base_mt
+        for cdf in comp_dfs.values():
+            cmt = set(zip(cdf["model"].tolist(), cdf["TP"].tolist()))
+            common_mt = common_mt.intersection(cmt)
+        common_mt = sorted(common_mt)
+
+        if not common_mt:
+            continue
+
+        all_common_conc: set = set()
+        for model, tp in common_mt:
+            conc_sets = [
+                set(
+                    df_base[(df_base["model"] == model) & (df_base["TP"] == tp)][
+                        "intended concurrency"
+                    ]
+                    .dropna()
+                    .unique()
+                )
+            ]
+            for cdf in comp_dfs.values():
+                conc_sets.append(
+                    set(
+                        cdf[(cdf["model"] == model) & (cdf["TP"] == tp)][
+                            "intended concurrency"
+                        ]
+                        .dropna()
+                        .unique()
+                    )
+                )
+            intersection = conc_sets[0]
+            for cs in conc_sets[1:]:
+                intersection = intersection.intersection(cs)
+            all_common_conc.update(intersection)
+
+        conc_set = {c for c in all_common_conc if c > 1}
+
+        all_versions = [baseline] + list(competitors)
+
+        summary_data = []
+        for model, tp in common_mt:
+            model_short = model.split("/")[-1] if "/" in model else model
+            tp_str = f"(TP={int(tp)})" if pd.notna(tp) else ""
+            row = {"Model": f"{model_short} {tp_str}"}
+
+            base_data = df_base[(df_base["model"] == model) & (df_base["TP"] == tp)]
+
+            for metric_name, mcfg in metrics_config.items():
+                col = mcfg["column"]
+                higher_is_better = mcfg["higher_is_better"]
+
+                version_vals = {}
+                for ver in all_versions:
+                    if ver == baseline:
+                        ver_data = base_data
+                    else:
+                        ver_data = comp_dfs[ver][
+                            (comp_dfs[ver]["model"] == model)
+                            & (comp_dfs[ver]["TP"] == tp)
+                        ]
+                    common_conc = set(
+                        ver_data["intended concurrency"].dropna().unique()
+                    ).intersection(conc_set)
+                    vals = (
+                        ver_data[ver_data["intended concurrency"].isin(common_conc)][
+                            col
+                        ]
+                        .dropna()
+                        .tolist()
+                    )
+                    if vals:
+                        version_vals[ver] = geometric_mean(vals)
+
+                if len(version_vals) < len(all_versions):
+                    row[metric_name] = "N/A"
+                    continue
+
+                if higher_is_better:
+                    best_ver = max(version_vals, key=version_vals.get)
+                else:
+                    best_ver = min(version_vals, key=version_vals.get)
+
+                best_val = version_vals[best_ver]
+                margins = []
+                for other in all_versions:
+                    if other == best_ver:
+                        continue
+                    other_val = version_vals[other]
+                    if other_val == 0:
+                        continue
+                    pct = abs((best_val - other_val) / other_val) * 100
+                    other_short = other.split("-")[0] if "-" in other else other
+                    margins.append(f"+{pct:.1f}% vs {other_short}")
+
+                color = "🟢" if best_ver == baseline else "🔴"
+
+                margin_str = ", ".join(margins)
+                row[metric_name] = f"{color} {best_ver} ({margin_str})"
+
+            summary_data.append(row)
+
+        if summary_data:
+            conc_list = sorted(int(c) for c in conc_set)
+            profile_tabs_data[profile_short] = (
+                summary_data,
+                conc_list,
+                profile_full,
+            )
+
+    if not profile_tabs_data:
+        st.info("No overlapping data found for this three-way comparison group.")
+        return
+
+    three_way_col_config = {"Model": st.column_config.TextColumn("Model")}
+    for metric_name in metrics_config:
+        three_way_col_config[metric_name] = st.column_config.TextColumn(metric_name)
+
+    pair_key = f"{baseline}_vs_{'_vs_'.join(competitors)}".replace(" ", "_")
+
+    summary_metrics = set(metrics_config.keys())
+    per_profile_verdicts = []
+    for prof_label, (prof_data, _conc, _pf) in profile_tabs_data.items():
+        model_wins, model_losses, model_similar = 0, 0, 0
+        for row in prof_data:
+            mw, ml = 0, 0
+            for m in summary_metrics:
+                cell = row.get(m, "")
+                if cell.startswith("🟢"):
+                    mw += 1
+                elif cell.startswith("🔴"):
+                    ml += 1
+            if mw > ml:
+                model_wins += 1
+                verdict = "win"
+            elif ml > mw:
+                model_losses += 1
+                verdict = "loss"
+            else:
+                model_similar += 1
+                verdict = "similar"
+            if baseline not in group_scores:
+                group_scores[baseline] = {}
+            score_key = " & ".join(competitors)
+            if score_key not in group_scores[baseline]:
+                group_scores[baseline][score_key] = [0, 0, 0, []]
+            group_scores[baseline][score_key][3].append(
+                {
+                    "model": row["Model"],
+                    "profile": prof_label,
+                    "verdict": verdict,
+                    "wins": mw,
+                    "losses": ml,
+                    "similar": len(summary_metrics) - mw - ml,
+                }
+            )
+        total = model_wins + model_losses + model_similar
+        if total == 0:
+            icon = "🟡"
+        elif model_wins > model_losses:
+            icon = "🟢"
+        elif model_losses > model_wins:
+            icon = "🔴"
+        else:
+            icon = "🟡"
+        per_profile_verdicts.append(
+            f"{icon} {prof_label}: {model_wins} wins, {model_losses} losses, {model_similar} similar"
+        )
+        group_scores[baseline][score_key][0] += model_wins
+        group_scores[baseline][score_key][1] += model_losses
+        group_scores[baseline][score_key][2] += model_similar
+
+    verdict_str = " | ".join(per_profile_verdicts)
+    all_models = set()
+    for _pl, (pdata, _c, _pf) in profile_tabs_data.items():
+        for row in pdata:
+            all_models.add(row["Model"])
+    models_str = ", ".join(sorted(all_models))
+    expander_label = (
+        f"{baseline} vs {' vs '.join(competitors)}  —  {verdict_str}  \n"
+        f"Models: {models_str}"
+    )
+
+    with st.expander(expander_label, expanded=False):
+        tab_labels = list(profile_tabs_data.keys())
+        tabs = st.tabs(tab_labels)
+        for tab, label in zip(tabs, tab_labels):
+            with tab:
+                summary_data, conc_list, prof_full = profile_tabs_data[label]
+                st.markdown(f"**NVIDIA H200 GPU, ISL/OSL: {label}**")
+                st.caption(
+                    f"ℹ️ Geometric mean metrics use concurrency levels: "
+                    f"{', '.join(str(c) for c in conc_list)} "
+                    f"(C=1 excluded — not representative of production workloads)."
+                )
+                summary_df = pd.DataFrame(summary_data)
+                df_key = f"ca_3w_{pair_key}_{label}"
+                tbl_height = 38 + len(summary_df) * 35 + 2
+                st.dataframe(
+                    summary_df,
+                    use_container_width=True,
+                    hide_index=True,
+                    column_config=three_way_col_config,
+                    key=df_key,
+                    height=tbl_height,
+                )
+                st.markdown(
+                    f"**Legend:** "
+                    f"🟢 {baseline} is the best performer | "
+                    f"🔴 A competitor outperforms {baseline}"
+                )
 
 
 def render_competitive_analysis_section(df):
@@ -1373,7 +1864,12 @@ def render_competitive_analysis_section(df):
 
     @st.dialog("Competitive Analysis — Metric Details", width="large")
     def _show_ca_metric_dialog(
-        metric_name, baseline, competitor, profile_full, profile_short
+        metric_name,
+        baseline,
+        competitor,
+        profile_full,
+        profile_short,
+        baseline_fallback_ver=None,
     ):
         mcfg = metrics_config[metric_name]
         col_name = mcfg["column"]
@@ -1387,9 +1883,14 @@ def render_competitive_analysis_section(df):
             f"**{ACCELERATOR}** &nbsp;|&nbsp; ISL/OSL: **{profile_short}**"
         )
 
-        df_base = h200_df[
-            (h200_df["version"] == baseline) & (h200_df["profile"] == profile_full)
-        ]
+        if baseline_fallback_ver:
+            df_base = _resolve_baseline_df(
+                h200_df, baseline, baseline_fallback_ver, profile_full
+            )
+        else:
+            df_base = h200_df[
+                (h200_df["version"] == baseline) & (h200_df["profile"] == profile_full)
+            ]
         df_comp = h200_df[
             (h200_df["version"] == competitor) & (h200_df["profile"] == profile_full)
         ]
@@ -1411,6 +1912,12 @@ def render_competitive_analysis_section(df):
             d1 = df_base[(df_base["model"] == m) & (df_base["TP"] == tp)]
             d2 = df_comp[(df_comp["model"] == m) & (df_comp["TP"] == tp)]
 
+            actual_base_ver = baseline
+            if baseline_fallback_ver and "version" in d1.columns:
+                src_versions = d1["version"].unique()
+                if len(src_versions) == 1:
+                    actual_base_ver = src_versions[0]
+
             c1 = set(d1["intended concurrency"].dropna().unique())
             c2 = set(d2["intended concurrency"].dropna().unique())
             cc = c1.intersection(c2)
@@ -1431,7 +1938,13 @@ def render_competitive_analysis_section(df):
                 continue
 
             per_model.append(
-                {"label": lbl, "conc": cc_sorted, "v1": v1_by_c, "v2": v2_by_c}
+                {
+                    "label": lbl,
+                    "conc": cc_sorted,
+                    "v1": v1_by_c,
+                    "v2": v2_by_c,
+                    "base_ver": actual_base_ver,
+                }
             )
 
         if not per_model:
@@ -1448,18 +1961,19 @@ def render_competitive_analysis_section(df):
             c_bl = _palette_baseline[idx % len(_palette_baseline)]
             c_cp = _palette_competitor[idx % len(_palette_competitor)]
             x_vals = [int(c) for c in md["conc"]]
+            bv = md.get("base_ver", baseline)
 
             fig.add_trace(
                 go.Scatter(
                     x=x_vals,
                     y=md["v1"],
                     mode="lines+markers",
-                    name=f"{md['label']} ({baseline})",
+                    name=f"{md['label']} ({bv})",
                     line={"color": c_bl, "width": 2.5},
                     marker={"size": 8},
                     legendgroup=md["label"],
                     hovertemplate=(
-                        f"<b>{md['label']}</b> — {baseline}<br>"
+                        f"<b>{md['label']}</b> — {bv}<br>"
                         "Concurrency: %{x}<br>"
                         "Value: %{y:,.2f}<extra></extra>"
                     ),
@@ -1516,10 +2030,13 @@ def render_competitive_analysis_section(df):
         dlg_key = f"ca_dlg_{metric_name}_{baseline}_{competitor}_{profile_short}"
         st.plotly_chart(fig, use_container_width=True, key=dlg_key, theme=None)
 
+        base_label = baseline
+        if baseline_fallback_ver:
+            base_label = f"{baseline} / {baseline_fallback_ver}"
         st.caption(
             "💡 **Tip:** Click a legend entry to toggle it. "
             "Double-click to isolate a single trace. "
-            f"Warm colors (reds/oranges) = **{baseline}**, "
+            f"Warm colors (reds/oranges) = **{base_label}**, "
             f"cool colors (blues/greens) = **{competitor}**."
         )
 
@@ -1533,15 +2050,40 @@ def render_competitive_analysis_section(df):
             group_scores = {}
             score_placeholder = st.container()
 
+            baseline_fallback = group.get("baseline_fallback", {})
+            is_three_way = group.get("three_way", False)
+
+            if is_three_way:
+                _render_three_way_comparison(
+                    h200_df,
+                    group,
+                    baseline_fallback,
+                    PROFILES,
+                    metrics_config,
+                    column_config,
+                    score_placeholder,
+                    group_scores,
+                )
+                group_has_data = True
+                _render_ca_scorecard(score_placeholder, group_scores)
+                st.markdown("---")
+                continue
+
             for baseline in group["baselines"]:
                 for competitor in group["competitors"]:
                     profile_tabs_data = {}
 
                     for profile_full, profile_short in PROFILES:
-                        df_base = h200_df[
-                            (h200_df["version"] == baseline)
-                            & (h200_df["profile"] == profile_full)
-                        ].copy()
+                        fallback_ver = baseline_fallback.get(baseline)
+                        if fallback_ver:
+                            df_base = _resolve_baseline_df(
+                                h200_df, baseline, fallback_ver, profile_full
+                            )
+                        else:
+                            df_base = h200_df[
+                                (h200_df["version"] == baseline)
+                                & (h200_df["profile"] == profile_full)
+                            ].copy()
                         df_comp = h200_df[
                             (h200_df["version"] == competitor)
                             & (h200_df["profile"] == profile_full)
@@ -1666,10 +2208,32 @@ def render_competitive_analysis_section(df):
                                     ms += 1
                             if mw > ml:
                                 model_wins += 1
+                                verdict = "win"
                             elif ml > mw:
                                 model_losses += 1
+                                verdict = "loss"
                             else:
                                 model_similar += 1
+                                verdict = "similar"
+                            if baseline not in group_scores:
+                                group_scores[baseline] = {}
+                            if competitor not in group_scores[baseline]:
+                                group_scores[baseline][competitor] = [
+                                    0,
+                                    0,
+                                    0,
+                                    [],
+                                ]
+                            group_scores[baseline][competitor][3].append(
+                                {
+                                    "model": row["Model"],
+                                    "profile": prof_label,
+                                    "verdict": verdict,
+                                    "wins": mw,
+                                    "losses": ml,
+                                    "similar": ms,
+                                }
+                            )
                         total = model_wins + model_losses + model_similar
                         if total == 0:
                             icon = "🟡"
@@ -1682,10 +2246,6 @@ def render_competitive_analysis_section(df):
                         per_profile_verdicts.append(
                             f"{icon} {prof_label}: {model_wins} wins, {model_losses} losses, {model_similar} similar"
                         )
-                        if baseline not in group_scores:
-                            group_scores[baseline] = {}
-                        if competitor not in group_scores[baseline]:
-                            group_scores[baseline][competitor] = [0, 0, 0]
                         group_scores[baseline][competitor][0] += model_wins
                         group_scores[baseline][competitor][1] += model_losses
                         group_scores[baseline][competitor][2] += model_similar
@@ -1717,24 +2277,9 @@ def render_competitive_analysis_section(df):
                                     f"(C=1 excluded — not representative of production workloads). "
                                     f"Peak throughput uses all common concurrency levels."
                                 )
-                                summary_df = pd.DataFrame(summary_data)
-                                df_key = f"ca_{pair_key}_{label}"
-                                st.dataframe(
-                                    summary_df,
-                                    use_container_width=True,
-                                    hide_index=True,
-                                    column_config=column_config,
-                                    key=df_key,
-                                )
-                                st.markdown(
-                                    f"**Legend:** "
-                                    f"🟢 {baseline} performs better than {competitor} | "
-                                    f"🔴 {baseline} performs worse than {competitor} | "
-                                    f"🟡 Similar Performance (< 5% difference)"
-                                )
 
                                 st.markdown(
-                                    "**📊 Click a metric below to open a detailed comparison graph:**"
+                                    "**📊 Click a metric to open a detailed comparison graph:**"
                                 )
                                 btn_metrics = list(metrics_config.keys())
                                 btn_cols = st.columns(len(btn_metrics))
@@ -1754,74 +2299,30 @@ def render_competitive_analysis_section(df):
                                                 competitor,
                                                 prof_full,
                                                 label,
+                                                baseline_fallback_ver=baseline_fallback.get(
+                                                    baseline
+                                                ),
                                             )
 
-            if group_scores:
-                with score_placeholder:
-                    cols = st.columns(len(group_scores))
-                    for col, (bl, comp_dict) in zip(cols, group_scores.items()):
-                        all_w = sum(v[0] for v in comp_dict.values())
-                        all_l = sum(v[1] for v in comp_dict.values())
-                        all_s = sum(v[2] for v in comp_dict.values())
-                        all_decisive = all_w + all_l
-                        overall_wr = (
-                            (all_w / all_decisive * 100) if all_decisive > 0 else None
-                        )
-                        hue = (
-                            "green"
-                            if all_l == 0
-                            else ("yellow" if all_w > all_l else "red")
-                        )
-
-                        competitor_rows = ""
-                        for comp, (cw, cl, cs) in comp_dict.items():
-                            c_decisive = cw + cl
-                            cwr = (cw / c_decisive * 100) if c_decisive > 0 else None
-                            if cwr is None:
-                                wr_cls = "val-amber"
-                                wr_text = "—"
-                            else:
-                                wr_cls = (
-                                    "val-green"
-                                    if cwr >= 60
-                                    else ("val-amber" if cwr >= 40 else "val-red")
+                                summary_df = pd.DataFrame(summary_data)
+                                df_key = f"ca_{pair_key}_{label}"
+                                tbl_height = 38 + len(summary_df) * 35 + 2
+                                st.dataframe(
+                                    summary_df,
+                                    use_container_width=True,
+                                    hide_index=True,
+                                    column_config=column_config,
+                                    key=df_key,
+                                    height=tbl_height,
                                 )
-                                wr_text = f"{cwr:.0f}%"
-                            competitor_rows += f"""<div class="vllm-stat-row" style="margin-top:0.5rem;">
-<div class="vllm-stat" style="flex:2;"><div class="vllm-stat-label" style="font-size:1rem;">vs {comp}</div></div>
-<div class="vllm-stat"><div class="vllm-stat-label">Win Rate</div><div class="vllm-stat-value {wr_cls}">{wr_text}</div></div>
-<div class="vllm-stat"><div class="vllm-stat-label">Wins</div><div class="vllm-stat-value val-green">{cw}</div></div>
-<div class="vllm-stat"><div class="vllm-stat-label">Losses</div><div class="vllm-stat-value val-red">{cl}</div></div>
-<div class="vllm-stat"><div class="vllm-stat-label">Similar</div><div class="vllm-stat-value val-amber">{cs}</div></div>
-</div>"""
+                                st.markdown(
+                                    f"**Legend:** "
+                                    f"🟢 {baseline} performs better than {competitor} | "
+                                    f"🔴 {baseline} performs worse than {competitor} | "
+                                    f"🟡 Similar Performance (< 5% difference)"
+                                )
 
-                        with col:
-                            st.markdown(
-                                f"""<div class="vllm-scorecard vllm-hue-{hue}">
-<div class="vllm-scorecard-title">{bl} — Competitive Score</div>
-<div class="vllm-stat-row">
-<div class="vllm-stat">
-<div class="vllm-stat-label">Overall Win Rate</div>
-<div class="vllm-stat-value {"val-amber" if overall_wr is None else ("val-green" if overall_wr >= 60 else "val-red")}">{"—" if overall_wr is None else f"{overall_wr:.0f}%"}</div>
-</div>
-<div class="vllm-stat">
-<div class="vllm-stat-label">Model Wins</div>
-<div class="vllm-stat-value val-green">{all_w}</div>
-</div>
-<div class="vllm-stat">
-<div class="vllm-stat-label">Model Losses</div>
-<div class="vllm-stat-value val-red">{all_l}</div>
-</div>
-<div class="vllm-stat">
-<div class="vllm-stat-label">Similar</div>
-<div class="vllm-stat-value val-amber">{all_s}</div>
-</div>
-</div>
-<hr style="margin:0.6rem 0;border:none;border-top:1px solid rgba(0,0,0,0.1);">
-{competitor_rows}
-</div>""",
-                                unsafe_allow_html=True,
-                            )
+            _render_ca_scorecard(score_placeholder, group_scores)
 
             if not group_has_data:
                 st.info("No overlapping data found for this comparison group.")

--- a/dashboard.py
+++ b/dashboard.py
@@ -62,6 +62,15 @@ except ImportError:
     LLMD_AVAILABLE = False
     print("Warning: llmd_dashboard module not found. LLM-D view will be disabled.")
 
+# Import vLLM CPU dashboard
+try:
+    from cpu_dashboard import render_cpu_dashboard
+
+    CPU_AVAILABLE = True
+except ImportError:
+    CPU_AVAILABLE = False
+    print("Warning: cpu_dashboard module not found. vLLM CPU view will be disabled.")
+
 # Configure logging to stdout for container logs
 logging.basicConfig(
     level=logging.INFO,
@@ -74,6 +83,7 @@ logger = logging.getLogger(__name__)
 S3_BUCKET = os.environ.get("S3_BUCKET")
 S3_KEY = os.environ.get("S3_KEY", "consolidated_dashboard.csv")
 S3_KEY_LLMD = os.environ.get("S3_KEY_LLMD", "llmd-dashboard.csv")
+S3_KEY_CPU = os.environ.get("S3_KEY_CPU", "cpu_dashboard.csv")
 S3_REGION = os.environ.get("S3_REGION", "us-east-1")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
@@ -730,6 +740,7 @@ def _compute_overview_data(
         all_conc = set(cd["intended concurrency"].dropna().unique()) | set(
             pd_["intended concurrency"].dropna().unique()
         )
+        conc_for_geomean = {c for c in all_conc if c > 1}
         row = {
             "model": model,
             "short_name": _short_model_name(model),
@@ -739,7 +750,9 @@ def _compute_overview_data(
             "custom_isl_osl": cisl_osl,
         }
         for mname, mc in metrics_cfg.items():
-            pct, better, _, _, similar = compare_two_datasets(cd, pd_, mc, all_conc)
+            pct, better, _, _, similar = compare_two_datasets(
+                cd, pd_, mc, conc_for_geomean
+            )
             row[f"{mname}_pct"] = pct
             row[f"{mname}_better"] = better
             row[f"{mname}_similar"] = similar
@@ -922,12 +935,15 @@ def _compute_overview_data(
         all_conc = set(cd["intended concurrency"].dropna().unique()) | set(
             vd["intended concurrency"].dropna().unique()
         )
-        pct, better, _, _, similar = compare_two_datasets(cd, vd, tput_cfg, all_conc)
+        conc_for_geomean = {c for c in all_conc if c > 1}
+        pct, better, _, _, similar = compare_two_datasets(
+            cd, vd, tput_cfg, conc_for_geomean
+        )
         ttft_pct, ttft_better, _, _, ttft_similar = compare_two_datasets(
-            cd, vd, ttft_cfg, all_conc
+            cd, vd, ttft_cfg, conc_for_geomean
         )
         itl_pct, itl_better, _, _, itl_similar = compare_two_datasets(
-            cd, vd, itl_cfg, all_conc
+            cd, vd, itl_cfg, conc_for_geomean
         )
         profile_label = (
             format_custom_isl_osl(cisl_osl) if cisl_osl else clean_profile_name(profile)
@@ -1189,9 +1205,59 @@ def render_competitive_analysis_section(df):
             padding: 0.8rem 1.5rem;
             font-weight: 600;
             min-height: 50px;
+            transition: all 0.3s ease;
         }
         .st-key-ca_section .stTabs [data-baseweb="tab-list"] button[aria-selected="true"] {
             font-size: 1.4rem;
+            animation: none;
+        }
+        .st-key-ca_section .stTabs [data-baseweb="tab-list"] button[aria-selected="false"] {
+            animation: ca-tab-pulse 1.8s ease-in-out infinite;
+            cursor: pointer;
+            background-color: rgba(59, 89, 152, 0.15);
+            border: 1.5px solid rgba(59, 89, 152, 0.35);
+            border-radius: 8px;
+        }
+        .st-key-ca_section .stTabs [data-baseweb="tab-list"] button[aria-selected="false"]:hover {
+            animation: none;
+            transform: translateY(-3px) scale(1.03);
+            box-shadow: 0 6px 18px rgba(59, 89, 152, 0.4);
+            background-color: rgba(59, 89, 152, 0.25);
+            border-color: rgba(59, 89, 152, 0.5);
+        }
+        @keyframes ca-tab-pulse {
+            0%, 100% {
+                box-shadow: 0 0 0 0 rgba(59, 89, 152, 0.05);
+                transform: translateY(0);
+            }
+            50% {
+                box-shadow: 0 2px 14px 0 rgba(59, 89, 152, 0.45);
+                transform: translateY(-2px);
+            }
+        }
+        .st-key-ca_section [data-testid="stExpander"] {
+            animation: ca-expander-glow 2.5s ease-in-out infinite !important;
+            transition: all 0.3s ease !important;
+            border-radius: 8px !important;
+            border: 1.5px solid rgba(59, 89, 152, 0.2) !important;
+        }
+        .st-key-ca_section [data-testid="stExpander"]:hover {
+            animation: none !important;
+            transform: translateY(-2px) !important;
+            box-shadow: 0 4px 14px rgba(59, 89, 152, 0.3) !important;
+            border-color: rgba(59, 89, 152, 0.5) !important;
+            background-color: rgba(59, 89, 152, 0.03) !important;
+        }
+        .st-key-ca_section [data-testid="stExpander"]:has(details[open]) {
+            animation: none !important;
+            box-shadow: none !important;
+            transform: none !important;
+            border-color: rgba(0, 0, 0, 0.1) !important;
+            background-color: transparent !important;
+        }
+        @keyframes ca-expander-glow {
+            0%, 100% { box-shadow: 0 0 0 0 rgba(59, 89, 152, 0); }
+            50% { box-shadow: 0 0 8px 1px rgba(59, 89, 152, 0.2); }
         }
         </style>""",
         unsafe_allow_html=True,
@@ -1515,7 +1581,7 @@ def render_competitive_analysis_section(df):
                             )
                             all_common_conc.update(base_conc.intersection(comp_conc))
 
-                        conc_set = all_common_conc
+                        conc_set = {c for c in all_common_conc if c > 1}
 
                         summary_data = []
                         for model, tp in common_model_tp:
@@ -1647,7 +1713,8 @@ def render_competitive_analysis_section(df):
                                 st.markdown(f"**NVIDIA H200 GPU, ISL/OSL: {label}**")
                                 st.caption(
                                     f"ℹ️ Geometric mean metrics use concurrency levels: "
-                                    f"{', '.join(str(c) for c in conc_list)}. "
+                                    f"{', '.join(str(c) for c in conc_list)} "
+                                    f"(C=1 excluded — not representative of production workloads). "
                                     f"Peak throughput uses all common concurrency levels."
                                 )
                                 summary_df = pd.DataFrame(summary_data)
@@ -1679,6 +1746,7 @@ def render_competitive_analysis_section(df):
                                             f"📊 {short}",
                                             key=btn_key,
                                             use_container_width=True,
+                                            type="primary",
                                         ):
                                             _show_ca_metric_dialog(
                                                 m_name,
@@ -4616,16 +4684,20 @@ def render_compare_versions_summary_section(df, use_expander=True):
         if all_common_concurrencies_sorted:
             # Key includes filter selections so the widget resets when filters change
             conc_key = f"compare_summary_conc_{version_1}_{version_2}_{selected_accelerator}_{selected_profile}"
+            default_concurrencies = [
+                c for c in all_common_concurrencies_sorted if c > 1
+            ]
             selected_concurrencies = st.multiselect(
                 "Select Concurrency Level(s) for Geometric Mean",
                 options=all_common_concurrencies_sorted,
-                default=all_common_concurrencies_sorted,
+                default=default_concurrencies or all_common_concurrencies_sorted,
                 key=conc_key,
                 on_change=keep_expander_open,
                 args=("compare_versions_summary_expanded",),
                 help=(
                     "Choose which concurrency levels to include in geometric mean calculations. "
                     "Only concurrency levels common to both versions are shown. "
+                    "Concurrency 1 is excluded by default (not representative of production workloads). "
                     "Peak throughput always uses all available concurrency levels."
                 ),
             )
@@ -4635,7 +4707,8 @@ def render_compare_versions_summary_section(df, use_expander=True):
             selected_conc_set = set(selected_concurrencies)
             st.caption(
                 f"ℹ️ Geometric mean metrics use concurrency levels: "
-                f"{', '.join(str(c) for c in sorted(selected_concurrencies))}. "
+                f"{', '.join(str(c) for c in sorted(selected_concurrencies))} "
+                f"(C=1 excluded by default — not representative of production workloads). "
                 f"Peak throughput uses all common concurrency levels."
             )
         else:
@@ -4922,8 +4995,6 @@ def render_compare_versions_summary_section(df, use_expander=True):
                     c1 = set(d1["intended concurrency"].dropna().unique())
                     c2 = set(d2["intended concurrency"].dropna().unique())
                     cc = c1.intersection(c2)
-                    if agg == "geom_mean":
-                        cc = cc.intersection(selected_conc_set)
                     if not cc:
                         continue
 
@@ -5057,8 +5128,8 @@ def render_compare_versions_summary_section(df, use_expander=True):
                 if agg == "geom_mean":
                     conc_str = ", ".join(str(int(c)) for c in sorted(selected_conc_set))
                     st.caption(
-                        f"ℹ️ Showing data at concurrency levels: {conc_str} "
-                        "(filtered by geometric mean concurrency selection)."
+                        f"ℹ️ Graph shows all common concurrency levels. "
+                        f"Geometric mean uses: {conc_str}."
                     )
                 else:
                     st.caption(
@@ -5442,16 +5513,20 @@ def render_compare_models_section(filtered_df, selected_profile, use_expander=Tr
 
         if all_common_concurrencies_sorted:
             conc_key = f"compare_models_conc_{model_1}_{model_2}"
+            default_concurrencies = [
+                c for c in all_common_concurrencies_sorted if c > 1
+            ]
             selected_concurrencies = st.multiselect(
                 "Select Concurrency Level(s) for Geometric Mean",
                 options=all_common_concurrencies_sorted,
-                default=all_common_concurrencies_sorted,
+                default=default_concurrencies or all_common_concurrencies_sorted,
                 key=conc_key,
                 on_change=keep_expander_open,
                 args=("compare_models_expanded",),
                 help=(
                     "Choose which concurrency levels to include in geometric mean calculations. "
                     "Only concurrency levels common to both models are shown. "
+                    "Concurrency 1 is excluded by default (not representative of production workloads). "
                     "Peak throughput always uses all available concurrency levels."
                 ),
             )
@@ -5461,7 +5536,8 @@ def render_compare_models_section(filtered_df, selected_profile, use_expander=Tr
             selected_conc_set = set(selected_concurrencies)
             st.caption(
                 f"ℹ️ Geometric mean metrics use concurrency levels: "
-                f"{', '.join(str(c) for c in sorted(selected_concurrencies))}. "
+                f"{', '.join(str(c) for c in sorted(selected_concurrencies))} "
+                f"(C=1 excluded by default — not representative of production workloads). "
                 f"Peak throughput uses all common concurrency levels."
             )
         else:
@@ -5682,8 +5758,6 @@ def render_compare_models_section(filtered_df, selected_profile, use_expander=Tr
                     c1 = set(d1["intended concurrency"].dropna().unique())
                     c2 = set(d2["intended concurrency"].dropna().unique())
                     cc = c1.intersection(c2)
-                    if agg == "geom_mean":
-                        cc = cc.intersection(selected_conc_set)
                     if not cc:
                         continue
 
@@ -5813,8 +5887,8 @@ def render_compare_models_section(filtered_df, selected_profile, use_expander=Tr
                 if agg == "geom_mean":
                     conc_str = ", ".join(str(int(c)) for c in sorted(selected_conc_set))
                     st.caption(
-                        f"ℹ️ Showing data at concurrency levels: {conc_str} "
-                        "(filtered by geometric mean concurrency selection)."
+                        f"ℹ️ Graph shows all common concurrency levels. "
+                        f"Geometric mean uses: {conc_str}."
                     )
                 else:
                     st.caption(
@@ -9116,6 +9190,8 @@ def render_sidebar_header():
             view_options.append("MLPerf Dashboard")
         if LLMD_AVAILABLE:
             view_options.append("LLM-D Dashboard")
+        if CPU_AVAILABLE:
+            view_options.append("vLLM CPU Dashboard")
 
         if len(view_options) > 1:
             # Pre-populate the widget key so we never need the `index`
@@ -9143,6 +9219,14 @@ def render_sidebar_header():
 
 def render_confidentiality_notice():
     """Render the confidentiality notice."""
+    selected_view = st.session_state.get("selected_view", "RHAIIS Dashboard")
+    gpu_infer_text = ""
+    if selected_view != "vLLM CPU Dashboard":
+        gpu_infer_text = (
+            "<b>For GPU sizing guidance and cost analysis, see "
+            '<a href="https://nb-qbits.github.io/gpuinfer/" target="_blank" '
+            'style="color:#92400e;text-decoration:underline;">GPU Infer</a>.</b>'
+        )
     st.markdown(
         '<div style="background-color: rgba(245,158,11,0.08); border-left: 3px solid #f59e0b; '
         "padding: 6px 12px; border-radius: 8px; font-size: 0.82rem; line-height: 1.5; "
@@ -9151,9 +9235,7 @@ def render_confidentiality_notice():
         "Red Hat Confidential. Disclosure requires signed NDA. "
         "External publication needs PSAP Inference Team approval "
         '(<span style="color:#92400e;">@psap-inference</span> on #forum-psap). '
-        "<b>For GPU sizing guidance and cost analysis, see "
-        '<a href="https://nb-qbits.github.io/gpuinfer/" target="_blank" '
-        'style="color:#92400e;text-decoration:underline;">GPU Infer</a>.</b>'
+        f"{gpu_infer_text}"
         "</div>",
         unsafe_allow_html=True,
     )
@@ -9167,7 +9249,12 @@ initialize_session_state()
 # must not overwrite it here — that would undo the user's click.
 if "view" in st.query_params and "dashboard_view_selector" not in st.session_state:
     view_from_url = st.query_params["view"]
-    if view_from_url in ["RHAIIS Dashboard", "MLPerf Dashboard", "LLM-D Dashboard"]:
+    if view_from_url in [
+        "RHAIIS Dashboard",
+        "MLPerf Dashboard",
+        "LLM-D Dashboard",
+        "vLLM CPU Dashboard",
+    ]:
         st.session_state.selected_view = view_from_url
         st.session_state.dashboard_view_selector = view_from_url
 
@@ -9303,6 +9390,11 @@ if MLPERF_AVAILABLE and selected_view == "MLPerf Dashboard":
 # If LLM-D view is selected, render LLM-D dashboard and exit
 if LLMD_AVAILABLE and selected_view == "LLM-D Dashboard":
     render_llmd_dashboard("llmd-dashboard.csv")
+    st.stop()  # Stop execution here, don't load RHAIIS data
+
+# If vLLM CPU view is selected, render CPU dashboard and exit
+if CPU_AVAILABLE and selected_view == "vLLM CPU Dashboard":
+    render_cpu_dashboard("cpu_dashboard.csv")
     st.stop()  # Stop execution here, don't load RHAIIS data
 
 # Otherwise, continue with RHAIIS dashboard

--- a/dashboard_styles.py
+++ b/dashboard_styles.py
@@ -1670,9 +1670,15 @@ def get_light_mode_css():
         color: #1a1f36 !important;
     }
 
-    /* Re-apply compare-version graph button styling (after catch-all overrides) */
+    /* Re-apply compare-version & competitive-analysis graph button styling (after catch-all overrides) */
     [class*="st-key-cmp_btn_"] button,
-    div[data-testid="stColumn"] [class*="st-key-cmp_btn_"] button {
+    div[data-testid="stColumn"] [class*="st-key-cmp_btn_"] button,
+    [class*="st-key-llmd_cmp_btn_"] button,
+    div[data-testid="stColumn"] [class*="st-key-llmd_cmp_btn_"] button,
+    [class*="st-key-ca_btn_"] button,
+    div[data-testid="stColumn"] [class*="st-key-ca_btn_"] button,
+    [class*="st-key-llmd_ca_btn_"] button,
+    div[data-testid="stColumn"] [class*="st-key-llmd_ca_btn_"] button {
         background: linear-gradient(135deg, #4a6fa5 0%, #3b5998 100%) !important;
         color: #ffffff !important;
         border: none !important;
@@ -1680,14 +1686,25 @@ def get_light_mode_css():
         box-shadow: 0 2px 6px rgba(59, 89, 152, 0.25) !important;
     }
     [class*="st-key-cmp_btn_"] button:hover,
-    div[data-testid="stColumn"] [class*="st-key-cmp_btn_"] button:hover {
+    div[data-testid="stColumn"] [class*="st-key-cmp_btn_"] button:hover,
+    [class*="st-key-llmd_cmp_btn_"] button:hover,
+    div[data-testid="stColumn"] [class*="st-key-llmd_cmp_btn_"] button:hover,
+    [class*="st-key-ca_btn_"] button:hover,
+    div[data-testid="stColumn"] [class*="st-key-ca_btn_"] button:hover,
+    [class*="st-key-llmd_ca_btn_"] button:hover,
+    div[data-testid="stColumn"] [class*="st-key-llmd_ca_btn_"] button:hover {
         background: linear-gradient(135deg, #3b5998 0%, #2d4373 100%) !important;
         color: #ffffff !important;
         box-shadow: 0 4px 14px rgba(59, 89, 152, 0.40) !important;
     }
     [class*="st-key-cmp_btn_"] button p,
     [class*="st-key-cmp_btn_"] button span,
-    .stButton [class*="st-key-cmp_btn_"] button span {
+    [class*="st-key-llmd_cmp_btn_"] button p,
+    [class*="st-key-llmd_cmp_btn_"] button span,
+    [class*="st-key-ca_btn_"] button p,
+    [class*="st-key-ca_btn_"] button span,
+    [class*="st-key-llmd_ca_btn_"] button p,
+    [class*="st-key-llmd_ca_btn_"] button span {
         color: #ffffff !important;
     }
 

--- a/deploy/openshift-deployment-staging.yaml
+++ b/deploy/openshift-deployment-staging.yaml
@@ -54,6 +54,8 @@ spec:
               value: "the location of the consolidated_dashboard.csv file"
             - name: S3_KEY_LLMD
               value: "the location of the llmd-dashboard.csv file"
+            - name: S3_KEY_CPU
+              value: "the location of the cpu_dashboard.csv file"
             - name: S3_REGION
               value: "the region of your bucket"
             # S3 Configuration for logs

--- a/llmd_dashboard.py
+++ b/llmd_dashboard.py
@@ -1667,13 +1667,21 @@ def render_compare_versions_section(df, use_expander=True):
             st.warning("⚠️ Need at least 2 versions in the data to compare.")
             return
 
+        _PREFERRED_V1 = "RHOAI-3.3-approximate"
+        _PREFERRED_V2 = "llm-d-0.4-approximate"
+        _PREFERRED_PROFILE = "128/128"
+
+        v1_default_index = 0
+        if _PREFERRED_V1 in available_versions:
+            v1_default_index = available_versions.index(_PREFERRED_V1)
+
         col1, col2, col3, col4 = st.columns(4)
 
         with col1:
             version_1 = st.selectbox(
                 "Select Version 1 (Baseline)",
                 options=available_versions,
-                index=0,
+                index=v1_default_index,
                 key="llmd_compare_v1",
                 on_change=_keep_expander_open,
                 args=("llmd_compare_versions_expanded",),
@@ -1681,11 +1689,14 @@ def render_compare_versions_section(df, use_expander=True):
 
         with col2:
             version_2_options = [v for v in available_versions if v != version_1]
+            v2_default_index = 0
+            if _PREFERRED_V2 in version_2_options:
+                v2_default_index = version_2_options.index(_PREFERRED_V2)
             version_2 = (
                 st.selectbox(
                     "Select Version 2 (Comparison)",
                     options=version_2_options,
-                    index=0 if version_2_options else None,
+                    index=v2_default_index if version_2_options else None,
                     key="llmd_compare_v2",
                     on_change=_keep_expander_open,
                     args=("llmd_compare_versions_expanded",),
@@ -1708,10 +1719,13 @@ def render_compare_versions_section(df, use_expander=True):
             )
 
         with col4:
+            profile_default_index = 0
+            if _PREFERRED_PROFILE in available_profiles:
+                profile_default_index = available_profiles.index(_PREFERRED_PROFILE)
             selected_profile = st.selectbox(
                 "Select ISL/OSL Profile",
                 options=available_profiles,
-                index=0,
+                index=profile_default_index,
                 format_func=clean_profile_name,
                 key="llmd_compare_profile",
                 on_change=_keep_expander_open,
@@ -1796,15 +1810,19 @@ def render_compare_versions_section(df, use_expander=True):
 
         if all_common_concurrencies_sorted:
             conc_key = f"llmd_compare_conc_{version_1}_{version_2}_{selected_accelerator}_{selected_profile}"
+            default_concurrencies = [
+                c for c in all_common_concurrencies_sorted if c > 1
+            ]
             selected_concurrencies = st.multiselect(
                 "Select Concurrency Level(s) for Geometric Mean",
                 options=all_common_concurrencies_sorted,
-                default=all_common_concurrencies_sorted,
+                default=default_concurrencies or all_common_concurrencies_sorted,
                 key=conc_key,
                 on_change=_keep_expander_open,
                 args=("llmd_compare_versions_expanded",),
                 help=(
                     "Choose which concurrency levels to include in geometric mean calculations. "
+                    "Concurrency 1 is excluded by default (not representative of production workloads). "
                     "Peak throughput always uses all available concurrency levels."
                 ),
             )
@@ -1814,7 +1832,8 @@ def render_compare_versions_section(df, use_expander=True):
             selected_conc_set = set(selected_concurrencies)
             st.caption(
                 f"ℹ️ Geometric mean metrics use concurrency levels: "
-                f"{', '.join(str(c) for c in sorted(selected_concurrencies))}. "
+                f"{', '.join(str(c) for c in sorted(selected_concurrencies))} "
+                f"(C=1 excluded by default — not representative of production workloads). "
                 f"Peak throughput uses all common concurrency levels."
             )
         else:
@@ -1960,7 +1979,6 @@ def render_compare_versions_section(df, use_expander=True):
             def _show_metric_dialog(metric_name):
                 mcfg = metrics_config[metric_name]
                 col = mcfg["column"]
-                agg = mcfg["aggregation"]
 
                 display_title = metric_name.replace(" (Geometric Mean)", "").replace(
                     " (Peak)", ""
@@ -2004,8 +2022,6 @@ def render_compare_versions_section(df, use_expander=True):
                     c1 = set(d1["intended concurrency"].dropna().unique())
                     c2 = set(d2["intended concurrency"].dropna().unique())
                     cc = c1.intersection(c2)
-                    if agg == "geom_mean":
-                        cc = cc.intersection(selected_conc_set)
                     if not cc:
                         continue
 
@@ -2140,6 +2156,7 @@ def render_compare_versions_section(df, use_expander=True):
                         f"📊 {short}",
                         key=f"llmd_cmp_btn_{i}",
                         use_container_width=True,
+                        type="primary",
                     ):
                         st.session_state.llmd_compare_versions_expanded = True
                         _show_metric_dialog(m_name)
@@ -2933,6 +2950,715 @@ def _decode_llmd_url_filters(df: pd.DataFrame) -> dict:
     return result
 
 
+LLMD_CA_CONFIGURATIONS = [
+    {
+        "label": "llm-d v0.5 vs Dynamo",
+        "description": (
+            "Performance comparison of **llm-d v0.5** against "
+            "**Dynamo v1.0.1** (vLLM backend) on **NVIDIA H200** "
+            "with GPT-OSS-120B (8 replicas, TP=1)."
+        ),
+        "groups": [
+            {
+                "title": "llm-d vs Dynamo — Inference Scheduling",
+                "description": (
+                    "How **llm-d v0.5** compares to **Dynamo v1.0.1** "
+                    "on multi-turn workload (128/128 tokens, 5 turns, "
+                    "prefix caching) with 8 replicas."
+                ),
+                "baselines": ["llm-d-0.5"],
+                "competitors": ["Dynamo-v1.0.1"],
+            },
+        ],
+    },
+]
+
+
+def render_llmd_competitive_analysis_section(df):
+    """Render the Competitive Analysis section for the LLM-D dashboard.
+
+    Pre-computed comparison tables showing llm-d performance
+    against Dynamo on NVIDIA H200.
+    """
+    header_col, _spacer, dropdown_col = st.columns([4, 4, 2])
+    with header_col:
+        st.header("Competitive Analysis")
+    with dropdown_col:
+        st.markdown("<div style='height: 1.1rem'></div>", unsafe_allow_html=True)
+        if len(LLMD_CA_CONFIGURATIONS) > 1:
+            ca_labels = [
+                f"{cfg['label']} (Latest)" if i == 0 else f"{cfg['label']} (Previous)"
+                for i, cfg in enumerate(LLMD_CA_CONFIGURATIONS)
+            ]
+        else:
+            ca_labels = [cfg["label"] for cfg in LLMD_CA_CONFIGURATIONS]
+        selected_ca_label = st.selectbox(
+            "Select competitive analysis",
+            ca_labels,
+            index=0,
+            key="llmd_ca_config_selector",
+            label_visibility="collapsed",
+        )
+    selected_ca = LLMD_CA_CONFIGURATIONS[ca_labels.index(selected_ca_label)]
+    comparison_groups = selected_ca["groups"]
+
+    st.markdown(selected_ca["description"])
+    st.caption(
+        "Each comparison below shows a per-model summary: "
+        "a model is a **Win** if it has more metric wins than losses "
+        "(baseline outperforms by ≥5%), "
+        "a **Loss** if it has more metric losses than wins "
+        "(baseline underperforms by ≥5%), "
+        "and **Similar** otherwise. "
+        "Metrics evaluated: Output Throughput, Total Throughput, "
+        "End-to-End Latency, TTFT P95, and ITL P95 geometric means."
+    )
+
+    st.markdown(
+        """<style>
+        .st-key-llmd_ca_section .stTabs [data-baseweb="tab-list"] button {
+            font-size: 1.3rem;
+            padding: 0.8rem 1.5rem;
+            font-weight: 600;
+            min-height: 50px;
+            transition: all 0.3s ease;
+        }
+        .st-key-llmd_ca_section .stTabs [data-baseweb="tab-list"] button[aria-selected="true"] {
+            font-size: 1.4rem;
+            animation: none;
+        }
+        .st-key-llmd_ca_section .stTabs [data-baseweb="tab-list"] button[aria-selected="false"] {
+            animation: llmd-ca-tab-pulse 1.8s ease-in-out infinite;
+            cursor: pointer;
+            background-color: rgba(59, 89, 152, 0.15);
+            border: 1.5px solid rgba(59, 89, 152, 0.35);
+            border-radius: 8px;
+        }
+        .st-key-llmd_ca_section .stTabs [data-baseweb="tab-list"] button[aria-selected="false"]:hover {
+            animation: none;
+            transform: translateY(-3px) scale(1.03);
+            box-shadow: 0 6px 18px rgba(59, 89, 152, 0.4);
+            background-color: rgba(59, 89, 152, 0.25);
+            border-color: rgba(59, 89, 152, 0.5);
+        }
+        @keyframes llmd-ca-tab-pulse {
+            0%, 100% {
+                box-shadow: 0 0 0 0 rgba(59, 89, 152, 0.05);
+                transform: translateY(0);
+            }
+            50% {
+                box-shadow: 0 2px 14px 0 rgba(59, 89, 152, 0.45);
+                transform: translateY(-2px);
+            }
+        }
+        .st-key-llmd_ca_section [data-testid="stExpander"] {
+            animation: llmd-ca-expander-glow 2.5s ease-in-out infinite !important;
+            transition: all 0.3s ease !important;
+            border-radius: 8px !important;
+            border: 1.5px solid rgba(59, 89, 152, 0.2) !important;
+        }
+        .st-key-llmd_ca_section [data-testid="stExpander"]:hover {
+            animation: none !important;
+            transform: translateY(-2px) !important;
+            box-shadow: 0 4px 14px rgba(59, 89, 152, 0.3) !important;
+            border-color: rgba(59, 89, 152, 0.5) !important;
+            background-color: rgba(59, 89, 152, 0.03) !important;
+        }
+        .st-key-llmd_ca_section [data-testid="stExpander"]:has(details[open]) {
+            animation: none !important;
+            box-shadow: none !important;
+            transform: none !important;
+            border-color: rgba(0, 0, 0, 0.1) !important;
+            background-color: transparent !important;
+        }
+        @keyframes llmd-ca-expander-glow {
+            0%, 100% { box-shadow: 0 0 0 0 rgba(59, 89, 152, 0); }
+            50% { box-shadow: 0 0 8px 1px rgba(59, 89, 152, 0.2); }
+        }
+        </style>""",
+        unsafe_allow_html=True,
+    )
+
+    ACCELERATOR = "H200"
+
+    metrics_config = {
+        "Output Throughput (Geometric Mean)": {
+            "column": "output_tok/sec",
+            "aggregation": "geom_mean",
+            "higher_is_better": True,
+            "show_concurrency": False,
+        },
+        "Total Throughput (Geometric Mean)": {
+            "column": "total_tok/sec",
+            "aggregation": "geom_mean",
+            "higher_is_better": True,
+            "show_concurrency": False,
+        },
+        "End-to-End Latency (Geometric Mean)": {
+            "column": "request_latency_median",
+            "aggregation": "geom_mean",
+            "higher_is_better": False,
+            "show_concurrency": False,
+        },
+        "TTFT P95 (Geometric Mean)": {
+            "column": "ttft_p95",
+            "aggregation": "geom_mean",
+            "higher_is_better": False,
+            "show_concurrency": False,
+        },
+        "ITL P95 (Geometric Mean)": {
+            "column": "itl_p95",
+            "aggregation": "geom_mean",
+            "higher_is_better": False,
+            "show_concurrency": False,
+        },
+    }
+
+    column_config = {
+        "Model": st.column_config.TextColumn(
+            "Model",
+            help="Model name with tensor parallelism (TP) configuration",
+        ),
+        "Output Throughput (Geometric Mean)": st.column_config.TextColumn(
+            "Output Throughput (Geometric Mean)",
+            help="Geometric mean of output tok/sec across all common concurrency levels",
+        ),
+        "Total Throughput (Geometric Mean)": st.column_config.TextColumn(
+            "Total Throughput (Geometric Mean)",
+            help="Geometric mean of total (input + output) tok/sec across all common concurrency levels",
+        ),
+        "End-to-End Latency (Geometric Mean)": st.column_config.TextColumn(
+            "End-to-End Latency (Geometric Mean)",
+            help="Geometric mean of request latency median across all common concurrency levels",
+        ),
+        "TTFT P95 (Geometric Mean)": st.column_config.TextColumn(
+            "TTFT P95 (Geometric Mean)",
+            help="Geometric mean of Time-to-First-Token (P95) across all common concurrency levels",
+        ),
+        "ITL P95 (Geometric Mean)": st.column_config.TextColumn(
+            "ITL P95 (Geometric Mean)",
+            help="Geometric mean of Inter-Token Latency (P95) across all common concurrency levels",
+        ),
+    }
+
+    h200_df = df[df["accelerator"] == ACCELERATOR]
+    if h200_df.empty:
+        st.warning("No NVIDIA H200 data available.")
+        return
+
+    _palette_baseline = [
+        "#EF553B",
+        "#FF7F0E",
+        "#D62728",
+        "#E377C2",
+        "#FF6692",
+        "#FFA15A",
+        "#FECB52",
+        "#F0027F",
+    ]
+    _palette_competitor = [
+        "#636EFA",
+        "#1F77B4",
+        "#00CC96",
+        "#19D3F3",
+        "#AB63FA",
+        "#17BECF",
+        "#2CA02C",
+        "#7F7F7F",
+    ]
+
+    @st.dialog("Competitive Analysis — Metric Details", width="large")
+    def _show_llmd_ca_metric_dialog(metric_name, baseline, competitor, profile_label):
+        mcfg = metrics_config[metric_name]
+        col_name = mcfg["column"]
+
+        display_title = metric_name.replace(" (Geometric Mean)", "").replace(
+            " (Peak)", ""
+        )
+        st.markdown(f"#### {display_title} vs Concurrency")
+        st.markdown(
+            f"**{baseline}** vs **{competitor}** &nbsp;|&nbsp; "
+            f"**{ACCELERATOR}** &nbsp;|&nbsp; ISL/OSL: **{profile_label}**"
+        )
+
+        df_base = h200_df[
+            (h200_df["version"] == baseline) & (h200_df["profile"] == profile_label)
+        ]
+        df_comp = h200_df[
+            (h200_df["version"] == competitor) & (h200_df["profile"] == profile_label)
+        ]
+
+        base_mt = set(zip(df_base["model"].tolist(), df_base["TP"].tolist()))
+        comp_mt = set(zip(df_comp["model"].tolist(), df_comp["TP"].tolist()))
+        common_mt = sorted(base_mt.intersection(comp_mt))
+
+        if not common_mt:
+            st.warning("No common models found.")
+            return
+
+        per_model = []
+        for m, tp in common_mt:
+            m_short = m.split("/")[-1] if "/" in m else m
+            tp_s = f" (TP={int(tp)})" if pd.notna(tp) else ""
+            lbl = f"{m_short}{tp_s}"
+
+            d1 = df_base[(df_base["model"] == m) & (df_base["TP"] == tp)]
+            d2 = df_comp[(df_comp["model"] == m) & (df_comp["TP"] == tp)]
+
+            c1 = set(d1["intended concurrency"].dropna().unique())
+            c2 = set(d2["intended concurrency"].dropna().unique())
+            cc = c1.intersection(c2)
+            if not cc:
+                continue
+
+            cc_sorted = sorted(cc)
+            v1_by_c, v2_by_c = [], []
+            for c in cc_sorted:
+                r1 = d1[d1["intended concurrency"] == c][col_name].values
+                r2 = d2[d2["intended concurrency"] == c][col_name].values
+                v1_by_c.append(float(r1[0]) if len(r1) > 0 else None)
+                v2_by_c.append(float(r2[0]) if len(r2) > 0 else None)
+
+            if not any(v is not None for v in v1_by_c) and not any(
+                v is not None for v in v2_by_c
+            ):
+                continue
+
+            per_model.append(
+                {"label": lbl, "conc": cc_sorted, "v1": v1_by_c, "v2": v2_by_c}
+            )
+
+        if not per_model:
+            st.warning("No data available for this metric.")
+            return
+
+        if col_name == "ttft_p95":
+            for md in per_model:
+                md["v1"] = [v / 1000 if v is not None else None for v in md["v1"]]
+                md["v2"] = [v / 1000 if v is not None else None for v in md["v2"]]
+
+        fig = go.Figure()
+        for idx, md in enumerate(per_model):
+            c_bl = _palette_baseline[idx % len(_palette_baseline)]
+            c_cp = _palette_competitor[idx % len(_palette_competitor)]
+            x_vals = [int(c) for c in md["conc"]]
+
+            fig.add_trace(
+                go.Scatter(
+                    x=x_vals,
+                    y=md["v1"],
+                    mode="lines+markers",
+                    name=f"{md['label']} ({baseline})",
+                    line={"color": c_bl, "width": 2.5},
+                    marker={"size": 8},
+                    legendgroup=md["label"],
+                    hovertemplate=(
+                        f"<b>{md['label']}</b> — {baseline}<br>"
+                        "Concurrency: %{x}<br>"
+                        "Value: %{y:,.2f}<extra></extra>"
+                    ),
+                )
+            )
+            fig.add_trace(
+                go.Scatter(
+                    x=x_vals,
+                    y=md["v2"],
+                    mode="lines+markers",
+                    name=f"{md['label']} ({competitor})",
+                    line={"color": c_cp, "width": 2.5},
+                    marker={"size": 8},
+                    legendgroup=md["label"],
+                    hovertemplate=(
+                        f"<b>{md['label']}</b> — {competitor}<br>"
+                        "Concurrency: %{x}<br>"
+                        "Value: %{y:,.2f}<extra></extra>"
+                    ),
+                )
+            )
+
+        if "tok/sec" in col_name:
+            y_title = "Tokens / sec"
+        elif "latency" in col_name.lower() or col_name == "ttft_p95":
+            y_title = "Seconds"
+        else:
+            y_title = "Milliseconds"
+
+        fig.update_layout(
+            height=600,
+            xaxis_title="Concurrency",
+            yaxis_title=y_title,
+            margin={"t": 30, "b": 60},
+            hovermode="x unified",
+            legend={
+                "orientation": "v",
+                "yanchor": "top",
+                "y": 1,
+                "xanchor": "left",
+                "x": 1.02,
+                "font": {"size": 11},
+                "itemclick": "toggle",
+                "itemdoubleclick": "toggleothers",
+            },
+            xaxis={
+                "type": "category",
+                "categoryorder": "array",
+                "categoryarray": sorted(
+                    {int(c) for md in per_model for c in md["conc"]}
+                ),
+            },
+        )
+        dlg_key = f"llmd_ca_dlg_{metric_name}_{baseline}_{competitor}_{profile_label}"
+        st.plotly_chart(fig, use_container_width=True, key=dlg_key, theme=None)
+
+        st.caption(
+            "Click a legend entry to toggle it. "
+            "Double-click to isolate a single trace. "
+            f"Warm colors (reds/oranges) = **{baseline}**, "
+            f"cool colors (blues/greens) = **{competitor}**."
+        )
+
+    ca_container = st.container(key="llmd_ca_section")
+    with ca_container:
+        for group in comparison_groups:
+            st.subheader(group["title"])
+            st.markdown(group["description"])
+
+            group_has_data = False
+            group_scores = {}
+            score_placeholder = st.container()
+
+            for baseline in group["baselines"]:
+                for competitor in group["competitors"]:
+                    base_all = h200_df[h200_df["version"] == baseline]
+                    comp_all = h200_df[h200_df["version"] == competitor]
+
+                    if base_all.empty or comp_all.empty:
+                        continue
+
+                    common_profiles = sorted(
+                        set(base_all["profile"].unique()).intersection(
+                            set(comp_all["profile"].unique())
+                        )
+                    )
+
+                    if not common_profiles:
+                        continue
+
+                    profile_tabs_data = {}
+
+                    for profile_label in common_profiles:
+                        df_base = base_all[base_all["profile"] == profile_label].copy()
+                        df_comp = comp_all[comp_all["profile"] == profile_label].copy()
+
+                        if df_base.empty or df_comp.empty:
+                            continue
+
+                        base_model_tp = set(
+                            zip(df_base["model"].tolist(), df_base["TP"].tolist())
+                        )
+                        comp_model_tp = set(
+                            zip(df_comp["model"].tolist(), df_comp["TP"].tolist())
+                        )
+                        common_model_tp = sorted(
+                            base_model_tp.intersection(comp_model_tp)
+                        )
+
+                        if not common_model_tp:
+                            continue
+
+                        all_common_conc: set = set()
+                        for model, tp in common_model_tp:
+                            base_conc = set(
+                                df_base[
+                                    (df_base["model"] == model) & (df_base["TP"] == tp)
+                                ]["intended concurrency"]
+                                .dropna()
+                                .unique()
+                            )
+                            comp_conc = set(
+                                df_comp[
+                                    (df_comp["model"] == model) & (df_comp["TP"] == tp)
+                                ]["intended concurrency"]
+                                .dropna()
+                                .unique()
+                            )
+                            all_common_conc.update(base_conc.intersection(comp_conc))
+
+                        conc_set = {c for c in all_common_conc if c > 1}
+
+                        summary_data = []
+                        for model, tp in common_model_tp:
+                            model_short_name = (
+                                model.split("/")[-1] if "/" in model else model
+                            )
+                            tp_str = f"(TP={int(tp)})" if pd.notna(tp) else ""
+                            row = {"Model": f"{model_short_name} {tp_str}"}
+
+                            base_data = df_base[
+                                (df_base["model"] == model) & (df_base["TP"] == tp)
+                            ]
+                            comp_data = df_comp[
+                                (df_comp["model"] == model) & (df_comp["TP"] == tp)
+                            ]
+
+                            for metric_name, mcfg in metrics_config.items():
+                                (
+                                    pct_diff,
+                                    base_better,
+                                    b_peak,
+                                    c_peak,
+                                    is_similar,
+                                ) = _compare_two_datasets(
+                                    base_data, comp_data, mcfg, conc_set
+                                )
+                                if pct_diff is None:
+                                    row[metric_name] = "N/A"
+                                else:
+                                    sign = "+" if pct_diff > 0 else ""
+                                    if mcfg["show_concurrency"] and b_peak is not None:
+                                        cell = (
+                                            f"{baseline} ({sign}{pct_diff:.1f}%) "
+                                            f"peak@{b_peak} vs {c_peak}"
+                                        )
+                                    else:
+                                        cell = f"{baseline} ({sign}{pct_diff:.1f}%)"
+                                    if is_similar:
+                                        color = "🟡"
+                                    elif base_better:
+                                        color = "🟢"
+                                    else:
+                                        color = "🔴"
+                                    row[metric_name] = f"{color} {cell}"
+
+                            summary_data.append(row)
+
+                        if summary_data:
+                            conc_list = sorted(int(c) for c in conc_set)
+                            profile_tabs_data[profile_label] = (
+                                summary_data,
+                                conc_list,
+                            )
+
+                    if not profile_tabs_data:
+                        continue
+
+                    group_has_data = True
+                    pair_key = f"{baseline}_vs_{competitor}".replace(" ", "_")
+
+                    summary_metrics = set(metrics_config.keys())
+
+                    per_profile_verdicts = []
+                    for prof_label, (
+                        prof_data,
+                        _conc,
+                    ) in profile_tabs_data.items():
+                        model_wins, model_losses, model_similar = 0, 0, 0
+                        for row in prof_data:
+                            mw, ml, ms = 0, 0, 0
+                            for m in summary_metrics:
+                                cell = row.get(m, "")
+                                if cell.startswith("🟢"):
+                                    mw += 1
+                                elif cell.startswith("🔴"):
+                                    ml += 1
+                                elif cell.startswith("🟡"):
+                                    ms += 1
+                            if mw > ml:
+                                model_wins += 1
+                            elif ml > mw:
+                                model_losses += 1
+                            else:
+                                model_similar += 1
+                        total = model_wins + model_losses + model_similar
+                        if total == 0:
+                            icon = "🟡"
+                        elif model_wins > model_losses:
+                            icon = "🟢"
+                        elif model_losses > model_wins:
+                            icon = "🔴"
+                        else:
+                            icon = "🟡"
+                        per_profile_verdicts.append(
+                            f"{icon} {prof_label}: {model_wins} wins, "
+                            f"{model_losses} losses, {model_similar} similar"
+                        )
+                        if baseline not in group_scores:
+                            group_scores[baseline] = {}
+                        if competitor not in group_scores[baseline]:
+                            group_scores[baseline][competitor] = [0, 0, 0]
+                        group_scores[baseline][competitor][0] += model_wins
+                        group_scores[baseline][competitor][1] += model_losses
+                        group_scores[baseline][competitor][2] += model_similar
+
+                    verdict_str = " | ".join(per_profile_verdicts)
+
+                    all_models = set()
+                    for _pl, (pdata, _c) in profile_tabs_data.items():
+                        for row in pdata:
+                            all_models.add(row["Model"])
+                    models_str = ", ".join(sorted(all_models))
+                    expander_label = (
+                        f"{baseline} vs {competitor}  —  {verdict_str}  \n"
+                        f"Models: {models_str}"
+                    )
+
+                    with st.expander(expander_label, expanded=False):
+                        tab_labels = list(profile_tabs_data.keys())
+                        tabs = st.tabs(tab_labels)
+                        for tab, label in zip(tabs, tab_labels):
+                            with tab:
+                                summary_data, conc_list = profile_tabs_data[label]
+                                st.markdown(f"**NVIDIA H200 GPU, ISL/OSL: {label}**")
+                                st.caption(
+                                    f"ℹ️ Geometric mean metrics use concurrency "
+                                    f"levels: "
+                                    f"{', '.join(str(c) for c in conc_list)} "
+                                    f"(C=1 excluded — not representative of "
+                                    f"production workloads)."
+                                )
+                                summary_df = pd.DataFrame(summary_data)
+                                df_key = f"llmd_ca_{pair_key}_{label}"
+                                st.dataframe(
+                                    summary_df,
+                                    use_container_width=True,
+                                    hide_index=True,
+                                    column_config=column_config,
+                                    key=df_key,
+                                )
+                                st.markdown(
+                                    f"**Legend:** "
+                                    f"🟢 {baseline} outperforms {competitor} | "
+                                    f"🔴 {baseline} underperforms {competitor} | "
+                                    f"🟡 Similar Performance (< 5% difference)"
+                                )
+
+                                st.markdown(
+                                    "**Click a metric below to open a "
+                                    "detailed comparison graph:**"
+                                )
+                                btn_metrics = list(metrics_config.keys())
+                                btn_cols = st.columns(len(btn_metrics))
+                                for btn_i, m_name in enumerate(btn_metrics):
+                                    with btn_cols[btn_i]:
+                                        short = m_name.replace(" (Geometric Mean)", "")
+                                        btn_key = (
+                                            f"llmd_ca_btn_{pair_key}_{label}_{btn_i}"
+                                        )
+                                        if st.button(
+                                            f"📊 {short}",
+                                            key=btn_key,
+                                            use_container_width=True,
+                                            type="primary",
+                                        ):
+                                            _show_llmd_ca_metric_dialog(
+                                                m_name,
+                                                baseline,
+                                                competitor,
+                                                label,
+                                            )
+
+            if group_scores:
+                with score_placeholder:
+                    cols = st.columns(len(group_scores))
+                    for col, (bl, comp_dict) in zip(cols, group_scores.items()):
+                        all_w = sum(v[0] for v in comp_dict.values())
+                        all_l = sum(v[1] for v in comp_dict.values())
+                        all_s = sum(v[2] for v in comp_dict.values())
+                        all_decisive = all_w + all_l
+                        overall_wr = (
+                            (all_w / all_decisive * 100) if all_decisive > 0 else None
+                        )
+                        hue = (
+                            "green"
+                            if all_l == 0
+                            else ("yellow" if all_w > all_l else "red")
+                        )
+
+                        competitor_rows = ""
+                        for comp, (cw, cl, cs) in comp_dict.items():
+                            c_decisive = cw + cl
+                            cwr = (cw / c_decisive * 100) if c_decisive > 0 else None
+                            if cwr is None:
+                                wr_cls = "val-amber"
+                                wr_text = "—"
+                            else:
+                                wr_cls = (
+                                    "val-green"
+                                    if cwr >= 60
+                                    else ("val-amber" if cwr >= 40 else "val-red")
+                                )
+                                wr_text = f"{cwr:.0f}%"
+                            competitor_rows += (
+                                f'<div class="vllm-stat-row" '
+                                f'style="margin-top:0.5rem;">'
+                                f'<div class="vllm-stat" style="flex:2;">'
+                                f'<div class="vllm-stat-label" '
+                                f'style="font-size:1rem;">vs {comp}</div></div>'
+                                f'<div class="vllm-stat">'
+                                f'<div class="vllm-stat-label">Win Rate</div>'
+                                f'<div class="vllm-stat-value {wr_cls}">'
+                                f"{wr_text}</div></div>"
+                                f'<div class="vllm-stat">'
+                                f'<div class="vllm-stat-label">Wins</div>'
+                                f'<div class="vllm-stat-value val-green">'
+                                f"{cw}</div></div>"
+                                f'<div class="vllm-stat">'
+                                f'<div class="vllm-stat-label">Losses</div>'
+                                f'<div class="vllm-stat-value val-red">'
+                                f"{cl}</div></div>"
+                                f'<div class="vllm-stat">'
+                                f'<div class="vllm-stat-label">Similar</div>'
+                                f'<div class="vllm-stat-value val-amber">'
+                                f"{cs}</div></div>"
+                                f"</div>"
+                            )
+
+                        wr_cls_overall = (
+                            "val-amber"
+                            if overall_wr is None
+                            else ("val-green" if overall_wr >= 60 else "val-red")
+                        )
+                        wr_text_overall = (
+                            "—" if overall_wr is None else f"{overall_wr:.0f}%"
+                        )
+                        with col:
+                            st.markdown(
+                                f'<div class="vllm-scorecard vllm-hue-{hue}">'
+                                f'<div class="vllm-scorecard-title">'
+                                f"{bl} — Competitive Score</div>"
+                                f'<div class="vllm-stat-row">'
+                                f'<div class="vllm-stat">'
+                                f'<div class="vllm-stat-label">'
+                                f"Overall Win Rate</div>"
+                                f'<div class="vllm-stat-value '
+                                f'{wr_cls_overall}">'
+                                f"{wr_text_overall}</div></div>"
+                                f'<div class="vllm-stat">'
+                                f'<div class="vllm-stat-label">'
+                                f"Model Wins</div>"
+                                f'<div class="vllm-stat-value val-green">'
+                                f"{all_w}</div></div>"
+                                f'<div class="vllm-stat">'
+                                f'<div class="vllm-stat-label">'
+                                f"Model Losses</div>"
+                                f'<div class="vllm-stat-value val-red">'
+                                f"{all_l}</div></div>"
+                                f'<div class="vllm-stat">'
+                                f'<div class="vllm-stat-label">Similar</div>'
+                                f'<div class="vllm-stat-value val-amber">'
+                                f"{all_s}</div></div></div>"
+                                f'<hr style="margin:0.6rem 0;border:none;'
+                                f'border-top:1px solid rgba(0,0,0,0.1);">'
+                                f"{competitor_rows}</div>",
+                                unsafe_allow_html=True,
+                            )
+
+            if not group_has_data:
+                st.info("No overlapping data found for this comparison group.")
+
+            st.markdown("---")
+
+
 def render_llmd_dashboard(llmd_csv_path: str):
     """Render the LLM-D benchmark dashboard.
 
@@ -2951,6 +3677,7 @@ def render_llmd_dashboard(llmd_csv_path: str):
         "📈 Performance Plots": "performance_plots",
         "⚖️ Compare Versions": "compare_versions",
         "🔄 Compare with RHAIIS": "rhaiis_comparison",
+        "🏆 Competitive Analysis": "competitive_analysis",
         "⚙️ Runtime Server Configs": "runtime_configs",
         "📄 Filtered Data": "filtered_data",
     }
@@ -3002,11 +3729,18 @@ def render_llmd_dashboard(llmd_csv_path: str):
         "📈 Performance Plots",
         "⚖️ Compare Versions",
         "🔄 Compare with RHAIIS",
+        "🏆 Competitive Analysis",
         "⚙️ Runtime Server Configs",
         "📄 Filtered Data",
     ]
 
     SECTION_GROUPS = [
+        (
+            "Dashboard",
+            [
+                "🏆 Competitive Analysis",
+            ],
+        ),
         (
             "Performance Analysis",
             [
@@ -3024,7 +3758,8 @@ def render_llmd_dashboard(llmd_csv_path: str):
         ),
     ]
 
-    current_section = st.session_state.get("llmd_active_section", section_list[0])
+    _default_section = "📈 Performance Plots"
+    current_section = st.session_state.get("llmd_active_section", _default_section)
     if current_section not in section_list:
         current_section = section_list[0]
     st.session_state.llmd_active_section = current_section
@@ -3032,6 +3767,7 @@ def render_llmd_dashboard(llmd_csv_path: str):
     LLMD_SECTIONS_WITHOUT_GLOBAL_FILTERS = {
         "⚖️ Compare Versions",
         "🔄 Compare with RHAIIS",
+        "🏆 Competitive Analysis",
     }
     _show_global_filters = current_section not in LLMD_SECTIONS_WITHOUT_GLOBAL_FILTERS
 
@@ -3074,6 +3810,8 @@ def render_llmd_dashboard(llmd_csv_path: str):
                 render_compare_versions_section(df, use_expander=False)
             elif sel == "🔄 Compare with RHAIIS":
                 render_rhaiis_comparison_section(df, use_expander=False)
+            elif sel == "🏆 Competitive Analysis":
+                render_llmd_competitive_analysis_section(df)
             elif sel == "⚙️ Runtime Server Configs":
                 render_runtime_configs_section(filtered_df, use_expander=False)
             elif sel == "📄 Filtered Data":

--- a/llmd_dashboard.py
+++ b/llmd_dashboard.py
@@ -3465,10 +3465,32 @@ def render_llmd_competitive_analysis_section(df):
                                     ms += 1
                             if mw > ml:
                                 model_wins += 1
+                                verdict = "win"
                             elif ml > mw:
                                 model_losses += 1
+                                verdict = "loss"
                             else:
                                 model_similar += 1
+                                verdict = "similar"
+                            if baseline not in group_scores:
+                                group_scores[baseline] = {}
+                            if competitor not in group_scores[baseline]:
+                                group_scores[baseline][competitor] = [
+                                    0,
+                                    0,
+                                    0,
+                                    [],
+                                ]
+                            group_scores[baseline][competitor][3].append(
+                                {
+                                    "model": row["Model"],
+                                    "profile": prof_label,
+                                    "verdict": verdict,
+                                    "wins": mw,
+                                    "losses": ml,
+                                    "similar": ms,
+                                }
+                            )
                         total = model_wins + model_losses + model_similar
                         if total == 0:
                             icon = "🟡"
@@ -3482,10 +3504,6 @@ def render_llmd_competitive_analysis_section(df):
                             f"{icon} {prof_label}: {model_wins} wins, "
                             f"{model_losses} losses, {model_similar} similar"
                         )
-                        if baseline not in group_scores:
-                            group_scores[baseline] = {}
-                        if competitor not in group_scores[baseline]:
-                            group_scores[baseline][competitor] = [0, 0, 0]
                         group_scores[baseline][competitor][0] += model_wins
                         group_scores[baseline][competitor][1] += model_losses
                         group_scores[baseline][competitor][2] += model_similar
@@ -3516,24 +3534,9 @@ def render_llmd_competitive_analysis_section(df):
                                     f"(C=1 excluded — not representative of "
                                     f"production workloads)."
                                 )
-                                summary_df = pd.DataFrame(summary_data)
-                                df_key = f"llmd_ca_{pair_key}_{label}"
-                                st.dataframe(
-                                    summary_df,
-                                    use_container_width=True,
-                                    hide_index=True,
-                                    column_config=column_config,
-                                    key=df_key,
-                                )
-                                st.markdown(
-                                    f"**Legend:** "
-                                    f"🟢 {baseline} outperforms {competitor} | "
-                                    f"🔴 {baseline} underperforms {competitor} | "
-                                    f"🟡 Similar Performance (< 5% difference)"
-                                )
 
                                 st.markdown(
-                                    "**Click a metric below to open a "
+                                    "**📊 Click a metric to open a "
                                     "detailed comparison graph:**"
                                 )
                                 btn_metrics = list(metrics_config.keys())
@@ -3557,6 +3560,24 @@ def render_llmd_competitive_analysis_section(df):
                                                 label,
                                             )
 
+                                summary_df = pd.DataFrame(summary_data)
+                                df_key = f"llmd_ca_{pair_key}_{label}"
+                                tbl_height = 38 + len(summary_df) * 35 + 2
+                                st.dataframe(
+                                    summary_df,
+                                    use_container_width=True,
+                                    hide_index=True,
+                                    column_config=column_config,
+                                    key=df_key,
+                                    height=tbl_height,
+                                )
+                                st.markdown(
+                                    f"**Legend:** "
+                                    f"🟢 {baseline} outperforms {competitor} | "
+                                    f"🔴 {baseline} underperforms {competitor} | "
+                                    f"🟡 Similar Performance (< 5% difference)"
+                                )
+
             if group_scores:
                 with score_placeholder:
                     cols = st.columns(len(group_scores))
@@ -3575,7 +3596,11 @@ def render_llmd_competitive_analysis_section(df):
                         )
 
                         competitor_rows = ""
-                        for comp, (cw, cl, cs) in comp_dict.items():
+                        for comp, score_entry in comp_dict.items():
+                            cw, cl, cs = score_entry[0], score_entry[1], score_entry[2]
+                            model_details = (
+                                score_entry[3] if len(score_entry) > 3 else []
+                            )
                             c_decisive = cw + cl
                             cwr = (cw / c_decisive * 100) if c_decisive > 0 else None
                             if cwr is None:
@@ -3588,6 +3613,65 @@ def render_llmd_competitive_analysis_section(df):
                                     else ("val-amber" if cwr >= 40 else "val-red")
                                 )
                                 wr_text = f"{cwr:.0f}%"
+
+                            models_by_name = {}
+                            for md in model_details:
+                                name = md["model"]
+                                if name not in models_by_name:
+                                    models_by_name[name] = {}
+                                models_by_name[name][md["profile"]] = md["verdict"]
+
+                            all_profiles = sorted(
+                                {md["profile"] for md in model_details}
+                            )
+                            detail_lines = ""
+                            for name, prof_verdicts in sorted(models_by_name.items()):
+                                profile_cells = ""
+                                for p in all_profiles:
+                                    v = prof_verdicts.get(p)
+                                    if v is None:
+                                        profile_cells += (
+                                            "<td style='padding:2px 8px;"
+                                            "text-align:center;'>—</td>"
+                                        )
+                                    else:
+                                        icon = {
+                                            "win": "🟢",
+                                            "loss": "🔴",
+                                            "similar": "🟡",
+                                        }[v]
+                                        profile_cells += (
+                                            f"<td style='padding:2px 8px;"
+                                            f"text-align:center;'>{icon}</td>"
+                                        )
+                                detail_lines += (
+                                    f"<tr>"
+                                    f"<td style='padding:2px 6px;'>{name}</td>"
+                                    f"{profile_cells}"
+                                    f"</tr>"
+                                )
+
+                            detail_table = ""
+                            if detail_lines:
+                                header_cells = "".join(
+                                    f"<th style='padding:2px 8px;"
+                                    f"text-align:center;'>{p}</th>"
+                                    for p in all_profiles
+                                )
+                                detail_table = (
+                                    f"<div style='margin-top:0.5rem;"
+                                    f"font-size:0.85rem;'>"
+                                    f"<table style='width:100%;"
+                                    f"border-collapse:collapse;'>"
+                                    f"<tr style='border-bottom:1px solid "
+                                    f"rgba(0,0,0,0.15);'>"
+                                    f"<th style='padding:2px 6px;"
+                                    f"text-align:left;'>Model</th>"
+                                    f"{header_cells}"
+                                    f"</tr>"
+                                    f"{detail_lines}</table></div>"
+                                )
+
                             competitor_rows += (
                                 f'<div class="vllm-stat-row" '
                                 f'style="margin-top:0.5rem;">'
@@ -3610,7 +3694,7 @@ def render_llmd_competitive_analysis_section(df):
                                 f'<div class="vllm-stat-label">Similar</div>'
                                 f'<div class="vllm-stat-value val-amber">'
                                 f"{cs}</div></div>"
-                                f"</div>"
+                                f"</div>{detail_table}"
                             )
 
                         wr_cls_overall = (
@@ -3624,8 +3708,13 @@ def render_llmd_competitive_analysis_section(df):
                         with col:
                             st.markdown(
                                 f'<div class="vllm-scorecard vllm-hue-{hue}">'
+                                f'<details><summary style="cursor:pointer;'
+                                f'list-style:none;">'
                                 f'<div class="vllm-scorecard-title">'
-                                f"{bl} — Competitive Score</div>"
+                                f"{bl} vs {' / '.join(comp_dict.keys())}"
+                                f'<span style="float:right;font-size:0.8rem;'
+                                f'opacity:0.6;">▼ click for details</span>'
+                                f"</div>"
                                 f'<div class="vllm-stat-row">'
                                 f'<div class="vllm-stat">'
                                 f'<div class="vllm-stat-label">'
@@ -3647,9 +3736,18 @@ def render_llmd_competitive_analysis_section(df):
                                 f'<div class="vllm-stat-label">Similar</div>'
                                 f'<div class="vllm-stat-value val-amber">'
                                 f"{all_s}</div></div></div>"
+                                f"</summary>"
                                 f'<hr style="margin:0.6rem 0;border:none;'
                                 f'border-top:1px solid rgba(0,0,0,0.1);">'
-                                f"{competitor_rows}</div>",
+                                f"{competitor_rows}"
+                                f'<div style="margin-top:0.6rem;'
+                                f'font-size:0.8rem;opacity:0.7;">'
+                                f"🟢 {bl} wins majority of metrics "
+                                f"&nbsp;|&nbsp; "
+                                f"🔴 {bl} loses majority of metrics "
+                                f"&nbsp;|&nbsp; "
+                                f"🟡 Similar (tied or &lt;5% diff)</div>"
+                                f"</details></div>",
                                 unsafe_allow_html=True,
                             )
 

--- a/mlperf_datacenter.py
+++ b/mlperf_datacenter.py
@@ -1106,6 +1106,7 @@ def create_benchmark_comparison_chart(
     # For CPU runs, fill in '# of Accelerators' with a display value
     cpu_mask = plot_df["Accelerator"].astype(str).str.startswith("cpu-", na=False)
     if cpu_mask.any():
+        plot_df["# of Accelerators"] = plot_df["# of Accelerators"].astype(object)
         plot_df.loc[cpu_mask, "# of Accelerators"] = "N/A (CPU)"
 
     if plot_df.empty:


### PR DESCRIPTION
## Summary

- **New vLLM CPU Dashboard** — Full `cpu_dashboard.py` module (1,141 lines) for CPU inference benchmarks with S3 data loading, sidebar view selector integration, and deployment config (`Dockerfile`, OpenShift env vars)
- **Competitive Analysis — Clickable Scorecards** — Scorecard summary blocks are now clickable `<details>` elements that expand to show a per-model breakdown with green/red/yellow icons per ISL/OSL profile (applied to both RHAIIS and LLM-D dashboards)
- **Competitive Analysis — vLLM-0.21.0 Config** — New three-way comparison tab (vLLM vs SGLang vs TRT-LLM) with baseline fallback logic (`_resolve_baseline_df`) that prefers `-competitive` version data per model when available
- **Metric Buttons Reordered** — Metric detail buttons moved above the comparison tables so users see the interactive controls before the data
- **Auto-sized DataFrames** — Table heights are now calculated from row count (`38 + len * 35 + 2`) to eliminate internal scrolling
- **C=1 Excluded from Geometric Means** — Concurrency 1 is now excluded by default from geometric mean calculations across Overview, Compare Versions, Compare Models, and Competitive Analysis (both RHAIIS and LLM-D) — captions updated to explain this
- **LLM-D Compare Versions Defaults** — Preferred defaults set for version selectors (`RHOAI-3.3-approximate` vs `llm-d-0.4-approximate`, profile `128/128`)
- **LLM-D Competitive Analysis** — New `render_llmd_competitive_analysis_section` with llm-d v0.5 vs Dynamo configuration, same clickable scorecard treatment
- **Confidentiality Notice** — GPU Infer link conditionally hidden on CPU dashboard view
- **Button Styling** — Gradient button CSS selectors extended to cover `ca_btn_` and `llmd_ca_btn_` keys in `dashboard_styles.py`
- **Bug Fix** — Cast `# of Accelerators` column to `object` before string assignment in `mlperf_datacenter.py` (pandas dtype error)

## Files Changed

| File | Change |
|------|--------|
| `cpu_dashboard.py` | New file — full CPU dashboard module |
| `dashboard.py` | +829 lines — vLLM-0.21.0 CA config, three-way comparison, clickable scorecards, baseline fallback, C=1 exclusion, CPU view integration |
| `llmd_dashboard.py` | +854 lines — LLM-D competitive analysis section, clickable scorecards, compare defaults, C=1 exclusion, button reorder |
| `dashboard_styles.py` | Extended gradient button CSS to new key patterns |
| `Dockerfile.openshift` | Copy `cpu_dashboard.py` and `cpu_dashboard.csv` |
| `deploy/openshift-deployment-staging.yaml` | Add `S3_KEY_CPU` env var |
| `mlperf_datacenter.py` | Fix pandas dtype cast for CPU accelerator column |
| `.gitignore` | Add `gpt-oss-dynamo-llmd/` |
