### PR TITLE
Add Gemma and GLM to model family patterns

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -706,6 +706,7 @@ _FAMILY_PATTERNS = [
     ("DeepSeek", ["deepseek"]),
     ("Nemotron", ["nemotron"]),
     ("BART", ["bart"]),
+    ("Gemma", ["gemma"]),
 ]
 
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -707,6 +707,7 @@ _FAMILY_PATTERNS = [
     ("Nemotron", ["nemotron"]),
     ("BART", ["bart"]),
     ("Gemma", ["gemma"]),
+    ("GLM", ["glm"]),
 ]
 
 


### PR DESCRIPTION
## Summary
- Adds `("Gemma", ["gemma"])` to `_FAMILY_PATTERNS` in `dashboard.py` so that Gemma models (e.g. `google/gemma-4-12B-it`, `RedHatAI/gemma-4-26B-A4B-it`) are grouped under "Gemma" instead of falling back to org-prefix.
- Adds `("GLM", ["glm"])` so that `zai-org/GLM-5-FP8` is grouped under "GLM" instead of "zai-org".

## Test plan
- [ ] Verify dashboard loads without errors
- [ ] Confirm models containing "gemma" are grouped under the "Gemma" family in the overview
- [ ] Confirm models containing "glm" are grouped under the "GLM" family in the overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)