### PR TITLE
Add multiturn benchmark support and request_type column (staging)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -6097,10 +6097,8 @@ def render_compare_versions_summary_section(df, use_expander=True):
             if _is_multiturn and len(config) == 5:
                 _, _, turns, pt, pc = config
                 mask = mask & (model_data["turns"] == turns)
-                if pt:
-                    mask = mask & (model_data["prefix_tokens"] == pt)
-                if pc:
-                    mask = mask & (model_data["prefix_count"] == pc)
+                mask = mask & (model_data["prefix_tokens"] == pt)
+                mask = mask & (model_data["prefix_count"] == pc)
             return model_data[mask]
 
         def _config_label(config):

--- a/dashboard.py
+++ b/dashboard.py
@@ -3770,8 +3770,15 @@ def render_performance_plots_section(filtered_df, use_expander=True):
                 lambda x: f" | PC={x}" if x else ""
             )
         if (filtered_df["turns"] > 1).any():
-            filtered_df["run_identifier"] += filtered_df["turns"].apply(
-                lambda x: f" | {x}T" if x > 1 else ""
+            filtered_df["run_identifier"] += filtered_df.apply(
+                lambda r: (
+                    f" | {r['turns']}T"
+                    + (f"/{r['prefix_tokens']}pt" if r.get("prefix_tokens") else "")
+                    + (f"/{r['prefix_count']}pc" if r.get("prefix_count") else "")
+                    if r["turns"] > 1
+                    else ""
+                ),
+                axis=1,
             )
 
         _sort_cols = ["model_short", "accelerator", "version", "TP"]
@@ -5821,7 +5828,7 @@ def render_compare_versions_summary_section(df, use_expander=True):
                         args=("compare_versions_summary_expanded",),
                     )
                 pt_scoped = mt_scoped
-                if compare_mt_turns:
+                if compare_mt_turns is not None:
                     pt_scoped = pt_scoped[pt_scoped["turns"].isin(compare_mt_turns)]
                 cmp_pt_opts = sorted(
                     v for v in pt_scoped["prefix_tokens"].unique() if v
@@ -5836,7 +5843,7 @@ def render_compare_versions_summary_section(df, use_expander=True):
                         args=("compare_versions_summary_expanded",),
                     )
                 pc_scoped = pt_scoped
-                if compare_mt_prefix_tokens:
+                if compare_mt_prefix_tokens is not None:
                     pc_scoped = pc_scoped[
                         pc_scoped["prefix_tokens"].isin(compare_mt_prefix_tokens)
                     ]
@@ -5995,17 +6002,17 @@ def render_compare_versions_summary_section(df, use_expander=True):
             base_mask_v2 = base_mask_v2 & (
                 df["multiturn_isl_osl"] == compare_mt_isl_osl
             )
-        if compare_mt_turns:
+        if compare_mt_turns is not None:
             base_mask_v1 = base_mask_v1 & df["turns"].isin(compare_mt_turns)
             base_mask_v2 = base_mask_v2 & df["turns"].isin(compare_mt_turns)
-        if compare_mt_prefix_tokens:
+        if compare_mt_prefix_tokens is not None:
             base_mask_v1 = base_mask_v1 & df["prefix_tokens"].isin(
                 compare_mt_prefix_tokens
             )
             base_mask_v2 = base_mask_v2 & df["prefix_tokens"].isin(
                 compare_mt_prefix_tokens
             )
-        if compare_mt_prefix_count:
+        if compare_mt_prefix_count is not None:
             base_mask_v1 = base_mask_v1 & df["prefix_count"].isin(
                 compare_mt_prefix_count
             )
@@ -11145,6 +11152,33 @@ def main():
             if "multiturn_isl_osl" in query_params:
                 url_multiturn_isl_osl = query_params["multiturn_isl_osl"].strip()
 
+            url_mt_turns = None
+            if "mt_turns" in query_params:
+                try:
+                    url_mt_turns = [
+                        int(t.strip())
+                        for t in query_params["mt_turns"].split(",")
+                        if t.strip().isdigit()
+                    ]
+                except Exception:
+                    url_mt_turns = None
+
+            url_mt_prefix_tokens = None
+            if "mt_prefix_tokens" in query_params:
+                url_mt_prefix_tokens = [
+                    v.strip()
+                    for v in query_params["mt_prefix_tokens"].split(",")
+                    if v.strip()
+                ]
+
+            url_mt_prefix_count = None
+            if "mt_prefix_count" in query_params:
+                url_mt_prefix_count = [
+                    v.strip()
+                    for v in query_params["mt_prefix_count"].split(",")
+                    if v.strip()
+                ]
+
             url_dp_sizes = []
             if "dp_sizes" in query_params:
                 try:
@@ -11208,6 +11242,9 @@ def main():
                 url_custom_isl_osl,
                 url_dp_sizes,
                 url_multiturn_isl_osl,
+                url_mt_turns,
+                url_mt_prefix_tokens,
+                url_mt_prefix_count,
             )
 
     df["profile"] = assign_profile_vectorized(df)
@@ -11302,6 +11339,9 @@ def main():
             url_custom_isl_osl,
             url_dp_sizes,
             url_multiturn_isl_osl,
+            url_mt_turns,
+            url_mt_prefix_tokens,
+            url_mt_prefix_count,
         ) = decode_filters_from_url()
 
         if url_section:
@@ -11382,6 +11422,12 @@ def main():
             st.session_state.selected_custom_isl_osl = url_custom_isl_osl
         if url_multiturn_isl_osl:
             st.session_state.selected_multiturn_isl_osl = url_multiturn_isl_osl
+        if url_mt_turns is not None:
+            st.session_state.baseline_mt_turns = url_mt_turns
+        if url_mt_prefix_tokens is not None:
+            st.session_state.baseline_mt_prefix_tokens = url_mt_prefix_tokens
+        if url_mt_prefix_count is not None:
+            st.session_state.baseline_mt_prefix_count = url_mt_prefix_count
 
     SECTIONS_WITHOUT_GLOBAL_FILTERS = {
         "🏠 Overview",
@@ -11766,40 +11812,62 @@ def main():
                         turns_key = (
                             f"mt_turns_filter_{st.session_state.filter_change_key}"
                         )
+                        _url_mt_turns = st.session_state.pop("baseline_mt_turns", None)
+                        turns_default = (
+                            [t for t in _url_mt_turns if t in turns_opts]
+                            if _url_mt_turns is not None
+                            else turns_opts
+                        )
                         selected_mt_turns = st.multiselect(
                             "Turns",
                             turns_opts,
-                            default=turns_opts,
+                            default=turns_default or turns_opts,
                             key=turns_key,
                         )
 
                     # Prefix tokens filter — scoped to ISL/OSL + turns
                     pt_temp = turns_temp
-                    if selected_mt_turns:
+                    if selected_mt_turns is not None:
                         pt_temp = pt_temp[pt_temp["turns"].isin(selected_mt_turns)]
                     pt_opts = sorted(v for v in pt_temp["prefix_tokens"].unique() if v)
                     if pt_opts:
                         pt_key = f"mt_prefix_tokens_filter_{st.session_state.filter_change_key}"
+                        _url_mt_pt = st.session_state.pop(
+                            "baseline_mt_prefix_tokens", None
+                        )
+                        pt_default = (
+                            [v for v in _url_mt_pt if v in pt_opts]
+                            if _url_mt_pt is not None
+                            else pt_opts
+                        )
                         selected_mt_prefix_tokens = st.multiselect(
                             "Prefix Tokens",
                             pt_opts,
-                            default=pt_opts,
+                            default=pt_default or pt_opts,
                             key=pt_key,
                         )
 
                     # Prefix count filter — scoped to ISL/OSL + turns + prefix_tokens
                     pc_temp = pt_temp
-                    if selected_mt_prefix_tokens:
+                    if selected_mt_prefix_tokens is not None:
                         pc_temp = pc_temp[
                             pc_temp["prefix_tokens"].isin(selected_mt_prefix_tokens)
                         ]
                     pc_opts = sorted(v for v in pc_temp["prefix_count"].unique() if v)
                     if pc_opts:
                         pc_mt_key = f"mt_prefix_count_filter_{st.session_state.filter_change_key}"
+                        _url_mt_pc = st.session_state.pop(
+                            "baseline_mt_prefix_count", None
+                        )
+                        pc_default = (
+                            [v for v in _url_mt_pc if v in pc_opts]
+                            if _url_mt_pc is not None
+                            else pc_opts
+                        )
                         selected_mt_prefix_count = st.multiselect(
                             "Prefix Count",
                             pc_opts,
-                            default=pc_opts,
+                            default=pc_default or pc_opts,
                             key=pc_mt_key,
                         )
 
@@ -11841,13 +11909,13 @@ def main():
                 temp_df = temp_df[
                     temp_df["multiturn_isl_osl"] == selected_multiturn_isl_osl
                 ]
-            if selected_mt_turns:
+            if selected_mt_turns is not None:
                 temp_df = temp_df[temp_df["turns"].isin(selected_mt_turns)]
-            if selected_mt_prefix_tokens:
+            if selected_mt_prefix_tokens is not None:
                 temp_df = temp_df[
                     temp_df["prefix_tokens"].isin(selected_mt_prefix_tokens)
                 ]
-            if selected_mt_prefix_count:
+            if selected_mt_prefix_count is not None:
                 temp_df = temp_df[
                     temp_df["prefix_count"].isin(selected_mt_prefix_count)
                 ]
@@ -12026,13 +12094,13 @@ def main():
                 temp_df = temp_df[
                     temp_df["multiturn_isl_osl"] == selected_multiturn_isl_osl
                 ]
-            if selected_mt_turns:
+            if selected_mt_turns is not None:
                 temp_df = temp_df[temp_df["turns"].isin(selected_mt_turns)]
-            if selected_mt_prefix_tokens:
+            if selected_mt_prefix_tokens is not None:
                 temp_df = temp_df[
                     temp_df["prefix_tokens"].isin(selected_mt_prefix_tokens)
                 ]
-            if selected_mt_prefix_count:
+            if selected_mt_prefix_count is not None:
                 temp_df = temp_df[
                     temp_df["prefix_count"].isin(selected_mt_prefix_count)
                 ]
@@ -12236,16 +12304,18 @@ def main():
             else True
         )
         mt_turns_mask = (
-            df["turns"].isin(selected_mt_turns) if selected_mt_turns else True
+            df["turns"].isin(selected_mt_turns)
+            if selected_mt_turns is not None
+            else True
         )
         mt_prefix_tokens_mask = (
             df["prefix_tokens"].isin(selected_mt_prefix_tokens)
-            if selected_mt_prefix_tokens
+            if selected_mt_prefix_tokens is not None
             else True
         )
         mt_prefix_count_mask = (
             df["prefix_count"].isin(selected_mt_prefix_count)
-            if selected_mt_prefix_count
+            if selected_mt_prefix_count is not None
             else True
         )
         tp_mask = df["TP"].isin(selected_tp) | df["TP"].isna()
@@ -12470,6 +12540,16 @@ def main():
                 mt_val = st.session_state.get("selected_multiturn_isl_osl")
                 if mt_val:
                     desired_params["multiturn_isl_osl"] = mt_val
+                if selected_mt_turns is not None:
+                    desired_params["mt_turns"] = ",".join(map(str, selected_mt_turns))
+                if selected_mt_prefix_tokens is not None:
+                    desired_params["mt_prefix_tokens"] = ",".join(
+                        map(str, selected_mt_prefix_tokens)
+                    )
+                if selected_mt_prefix_count is not None:
+                    desired_params["mt_prefix_count"] = ",".join(
+                        map(str, selected_mt_prefix_count)
+                    )
             if selected_tp:
                 desired_params["tp_sizes"] = ",".join(map(str, selected_tp))
             if st.session_state.get("show_advanced_filters", False) and selected_dp:

--- a/dashboard.py
+++ b/dashboard.py
@@ -10434,6 +10434,10 @@ def render_filtered_data_section(filtered_df, use_expander=True):
             cols.remove("view_logs_link")
             gml_idx = cols.index("grafana_metrics_link")
             cols.insert(gml_idx + 1, "view_logs_link")
+        if "request_type" in cols:
+            cols.remove("request_type")
+            ver_idx = cols.index("version")
+            cols.insert(ver_idx + 1, "request_type")
         if "Run Date" in cols:
             cols.remove("Run Date")
             cols.append("Run Date")
@@ -10462,6 +10466,10 @@ def render_filtered_data_section(filtered_df, use_expander=True):
                 "version",
                 help="Inference server version (e.g., RHAIIS-3.2.1, vLLM-0.10.0)",
                 pinned=True,
+            ),
+            "request_type": st.column_config.TextColumn(
+                "request type",
+                help="GuideLLM API endpoint type (e.g., chat_completions, completions)",
             ),
             "prompt toks": st.column_config.NumberColumn(
                 "prompt toks",
@@ -11261,6 +11269,10 @@ def main():
             )
         )
     )
+
+    if "request_type" not in df.columns:
+        df["request_type"] = ""
+    df["request_type"] = df["request_type"].fillna("").astype(str)
 
     df["error_rate"] = (
         df["errored_requests"]

--- a/dashboard.py
+++ b/dashboard.py
@@ -11882,8 +11882,12 @@ def main():
 
                     # Prefix tokens filter — scoped to ISL/OSL + turns
                     if selected_mt_turns:
-                        pt_temp = turns_temp[turns_temp["turns"].isin(selected_mt_turns)]
-                        pt_opts = sorted(v for v in pt_temp["prefix_tokens"].unique() if v)
+                        pt_temp = turns_temp[
+                            turns_temp["turns"].isin(selected_mt_turns)
+                        ]
+                        pt_opts = sorted(
+                            v for v in pt_temp["prefix_tokens"].unique() if v
+                        )
                         if pt_opts:
                             pt_key = f"mt_prefix_tokens_filter_{st.session_state.filter_change_key}"
                             _url_mt_pt = st.session_state.pop(
@@ -11906,7 +11910,9 @@ def main():
                         pc_temp = pt_temp[
                             pt_temp["prefix_tokens"].isin(selected_mt_prefix_tokens)
                         ]
-                        pc_opts = sorted(v for v in pc_temp["prefix_count"].unique() if v)
+                        pc_opts = sorted(
+                            v for v in pc_temp["prefix_count"].unique() if v
+                        )
                         if pc_opts:
                             pc_mt_key = f"mt_prefix_count_filter_{st.session_state.filter_change_key}"
                             _url_mt_pc = st.session_state.pop(

--- a/dashboard.py
+++ b/dashboard.py
@@ -6030,36 +6030,91 @@ def render_compare_versions_summary_section(df, use_expander=True):
             return
 
         _has_dp = "DP" in df_v1.columns
+        _is_multiturn = selected_profile == "Multi-turn"
 
         def _get_version_configs(df, model):
-            """Return sorted list of (type, value) parallelism configs for a model."""
+            """Return sorted list of config tuples for a model.
+
+            For Multi-turn: (ptype, pval, turns, prefix_tokens, prefix_count)
+            Otherwise: (ptype, pval)
+            """
             model_data = df[df["model"] == model]
-            configs = set()
+            base_configs = set()
             if _has_dp and model_data["DP"].notna().any():
                 for dp_val in model_data["DP"].dropna().unique():
-                    configs.add(("DP", int(dp_val)))
+                    base_configs.add(("DP", int(dp_val)))
             tp_data = model_data if not _has_dp else model_data[model_data["DP"].isna()]
             if not tp_data.empty and tp_data["TP"].notna().any():
                 for tp_val in tp_data["TP"].dropna().unique():
-                    configs.add(("TP", int(tp_val)))
-            return sorted(configs) if configs else [("N/A", 0)]
+                    base_configs.add(("TP", int(tp_val)))
+            if not base_configs:
+                base_configs = {("N/A", 0)}
+
+            if not _is_multiturn:
+                return sorted(base_configs)
+
+            # Expand each parallelism config by turns/prefix variants
+            configs = set()
+            for base in base_configs:
+                ptype, pval = base
+                if ptype == "DP" and _has_dp:
+                    subset = model_data[model_data["DP"] == pval]
+                elif ptype == "TP":
+                    mask = model_data["TP"] == pval
+                    if _has_dp:
+                        mask = mask & model_data["DP"].isna()
+                    subset = model_data[mask]
+                else:
+                    subset = model_data
+                for _, row in (
+                    subset[["turns", "prefix_tokens", "prefix_count"]]
+                    .drop_duplicates()
+                    .iterrows()
+                ):
+                    configs.add(
+                        (
+                            ptype,
+                            pval,
+                            row["turns"],
+                            row["prefix_tokens"],
+                            row["prefix_count"],
+                        )
+                    )
+            return sorted(configs)
 
         def _slice_by_config(df, model, config):
-            """Return rows matching model and parallelism config."""
+            """Return rows matching model and config tuple."""
             model_data = df[df["model"] == model]
-            ptype, pval = config
+            ptype, pval = config[0], config[1]
             if ptype == "DP" and _has_dp:
-                return model_data[model_data["DP"] == pval]
+                mask = model_data["DP"] == pval
             elif ptype == "TP":
                 mask = model_data["TP"] == pval
                 if _has_dp:
                     mask = mask & model_data["DP"].isna()
-                return model_data[mask]
-            return model_data
+            else:
+                mask = pd.Series(True, index=model_data.index)
+            if _is_multiturn and len(config) == 5:
+                _, _, turns, pt, pc = config
+                mask = mask & (model_data["turns"] == turns)
+                if pt:
+                    mask = mask & (model_data["prefix_tokens"] == pt)
+                if pc:
+                    mask = mask & (model_data["prefix_count"] == pc)
+            return model_data[mask]
 
         def _config_label(config):
-            ptype, pval = config
-            return f"{ptype}={pval}" if ptype != "N/A" else "N/A"
+            ptype, pval = config[0], config[1]
+            label = f"{ptype}={pval}" if ptype != "N/A" else "N/A"
+            if _is_multiturn and len(config) == 5:
+                _, _, turns, pt, pc = config
+                parts = [f"{turns}T"]
+                if pt:
+                    parts.append(f"{pt}pt")
+                if pc:
+                    parts.append(f"{pc}pc")
+                label += " " + "/".join(parts)
+            return label
 
         # Build comparison pairs: exact parallelism matches first, then
         # cross-parallelism pairs for models that differ (e.g. TP vs DP).

--- a/dashboard.py
+++ b/dashboard.py
@@ -3880,6 +3880,8 @@ def render_performance_plots_section(filtered_df, use_expander=True):
         _legend_parts = "Accelerator | Model | Version | TP"
         if _has_dp_data:
             _legend_parts += " | DP"
+        if (filtered_df_sorted["turns"] > 1).any():
+            _legend_parts += " | Turns/PrefixTokens/PrefixCount"
         fig.update_layout(
             legend_title_text=f"Run Details ({_legend_parts})",
             legend={"font": {"size": 14}},

--- a/dashboard.py
+++ b/dashboard.py
@@ -11869,60 +11869,58 @@ def main():
                         turns_default = (
                             [t for t in _url_mt_turns if t in turns_opts]
                             if _url_mt_turns is not None
-                            else turns_opts
+                            else []
                         )
                         selected_mt_turns = st.multiselect(
                             "Turns",
                             turns_opts,
-                            default=turns_default or turns_opts,
+                            default=turns_default,
                             key=turns_key,
                         )
 
                     # Prefix tokens filter — scoped to ISL/OSL + turns
-                    pt_temp = turns_temp
-                    if selected_mt_turns is not None:
-                        pt_temp = pt_temp[pt_temp["turns"].isin(selected_mt_turns)]
-                    pt_opts = sorted(v for v in pt_temp["prefix_tokens"].unique() if v)
-                    if pt_opts:
-                        pt_key = f"mt_prefix_tokens_filter_{st.session_state.filter_change_key}"
-                        _url_mt_pt = st.session_state.pop(
-                            "baseline_mt_prefix_tokens", None
-                        )
-                        pt_default = (
-                            [v for v in _url_mt_pt if v in pt_opts]
-                            if _url_mt_pt is not None
-                            else pt_opts
-                        )
-                        selected_mt_prefix_tokens = st.multiselect(
-                            "Prefix Tokens",
-                            pt_opts,
-                            default=pt_default or pt_opts,
-                            key=pt_key,
-                        )
+                    if selected_mt_turns:
+                        pt_temp = turns_temp[turns_temp["turns"].isin(selected_mt_turns)]
+                        pt_opts = sorted(v for v in pt_temp["prefix_tokens"].unique() if v)
+                        if pt_opts:
+                            pt_key = f"mt_prefix_tokens_filter_{st.session_state.filter_change_key}"
+                            _url_mt_pt = st.session_state.pop(
+                                "baseline_mt_prefix_tokens", None
+                            )
+                            pt_default = (
+                                [v for v in _url_mt_pt if v in pt_opts]
+                                if _url_mt_pt is not None
+                                else pt_opts
+                            )
+                            selected_mt_prefix_tokens = st.multiselect(
+                                "Prefix Tokens",
+                                pt_opts,
+                                default=pt_default or pt_opts,
+                                key=pt_key,
+                            )
 
                     # Prefix count filter — scoped to ISL/OSL + turns + prefix_tokens
-                    pc_temp = pt_temp
-                    if selected_mt_prefix_tokens is not None:
-                        pc_temp = pc_temp[
-                            pc_temp["prefix_tokens"].isin(selected_mt_prefix_tokens)
+                    if selected_mt_prefix_tokens:
+                        pc_temp = pt_temp[
+                            pt_temp["prefix_tokens"].isin(selected_mt_prefix_tokens)
                         ]
-                    pc_opts = sorted(v for v in pc_temp["prefix_count"].unique() if v)
-                    if pc_opts:
-                        pc_mt_key = f"mt_prefix_count_filter_{st.session_state.filter_change_key}"
-                        _url_mt_pc = st.session_state.pop(
-                            "baseline_mt_prefix_count", None
-                        )
-                        pc_default = (
-                            [v for v in _url_mt_pc if v in pc_opts]
-                            if _url_mt_pc is not None
-                            else pc_opts
-                        )
-                        selected_mt_prefix_count = st.multiselect(
-                            "Prefix Count",
-                            pc_opts,
-                            default=pc_default or pc_opts,
-                            key=pc_mt_key,
-                        )
+                        pc_opts = sorted(v for v in pc_temp["prefix_count"].unique() if v)
+                        if pc_opts:
+                            pc_mt_key = f"mt_prefix_count_filter_{st.session_state.filter_change_key}"
+                            _url_mt_pc = st.session_state.pop(
+                                "baseline_mt_prefix_count", None
+                            )
+                            pc_default = (
+                                [v for v in _url_mt_pc if v in pc_opts]
+                                if _url_mt_pc is not None
+                                else pc_opts
+                            )
+                            selected_mt_prefix_count = st.multiselect(
+                                "Prefix Count",
+                                pc_opts,
+                                default=pc_default or pc_opts,
+                                key=pc_mt_key,
+                            )
 
             # Update baseline_profile to remember user's current selection
             # This ensures the selected profile is retained when other filters change

--- a/dashboard.py
+++ b/dashboard.py
@@ -768,6 +768,7 @@ def _compute_overview_data(
                 d["dataset"],
                 d["spec_decoding"],
                 d["prefix_caching"],
+                d["turns"],
             )
         )
 
@@ -775,7 +776,7 @@ def _compute_overview_data(
 
     # Per-combo metric deltas (current vs previous)
     combo_results = []
-    for model, tp, accel, profile, cisl_osl, dset, sdec, pcache in common_combos:
+    for model, tp, accel, profile, cisl_osl, dset, sdec, pcache, turns in common_combos:
         mask_c = (
             (df_curr["model"] == model)
             & (df_curr["TP"] == tp)
@@ -785,6 +786,7 @@ def _compute_overview_data(
             & (df_curr["dataset"] == dset)
             & (df_curr["spec_decoding"] == sdec)
             & (df_curr["prefix_caching"] == pcache)
+            & (df_curr["turns"] == turns)
         )
         mask_p = (
             (df_prev["model"] == model)
@@ -795,6 +797,7 @@ def _compute_overview_data(
             & (df_prev["dataset"] == dset)
             & (df_prev["spec_decoding"] == sdec)
             & (df_prev["prefix_caching"] == pcache)
+            & (df_prev["turns"] == turns)
         )
         cd, pd_ = df_curr[mask_c], df_prev[mask_p]
         all_conc = set(cd["intended concurrency"].dropna().unique()) | set(
@@ -811,6 +814,7 @@ def _compute_overview_data(
             "dataset": dset,
             "spec_decoding": sdec,
             "prefix_caching": pcache,
+            "turns": turns,
         }
         for mname, mc in metrics_cfg.items():
             pct, better, _, _, similar = compare_two_datasets(
@@ -977,7 +981,7 @@ def _compute_overview_data(
     tput_cfg = metrics_cfg["Throughput"]
     ttft_cfg = metrics_cfg["TTFT P95"]
     itl_cfg = metrics_cfg["ITL P95"]
-    for model, tp, accel, profile, cisl_osl, dset, sdec, pcache in common_vllm:
+    for model, tp, accel, profile, cisl_osl, dset, sdec, pcache, turns in common_vllm:
         if accel != "H200":
             continue
         mask_c = (
@@ -989,6 +993,7 @@ def _compute_overview_data(
             & (df_curr["dataset"] == dset)
             & (df_curr["spec_decoding"] == sdec)
             & (df_curr["prefix_caching"] == pcache)
+            & (df_curr["turns"] == turns)
         )
         mask_v = (
             (df_vllm["model"] == model)
@@ -999,6 +1004,7 @@ def _compute_overview_data(
             & (df_vllm["dataset"] == dset)
             & (df_vllm["spec_decoding"] == sdec)
             & (df_vllm["prefix_caching"] == pcache)
+            & (df_vllm["turns"] == turns)
         )
         cd, vd = df_curr[mask_c], df_vllm[mask_v]
         all_conc = set(cd["intended concurrency"].dropna().unique()) | set(
@@ -1038,6 +1044,7 @@ def _compute_overview_data(
                 "dataset": dset,
                 "spec_decoding": sdec,
                 "prefix_caching": pcache,
+                "turns": turns,
             }
         )
 
@@ -1095,6 +1102,7 @@ def _compute_overview_data(
                     r.get("dataset", ""),
                     r.get("spec_decoding", ""),
                     r.get("prefix_caching", ""),
+                    r.get("turns", 1),
                 )
                 for _, r in rows.iterrows()
             }
@@ -1686,6 +1694,11 @@ def _render_three_way_comparison(
                     if pc:
                         pc_str = ", ".join(pc) if isinstance(pc, list) else pc
                         tab_subtitle += f" | Prefix Caching: {pc_str}"
+                    turns_f = st.session_state.get("selected_turns_filter", [])
+                    if turns_f and any(t > 1 for t in turns_f):
+                        tab_subtitle += (
+                            f" | Turns: {', '.join(str(t) for t in turns_f)}"
+                        )
                 st.markdown(f"**NVIDIA H200 GPU, ISL/OSL: {label}{tab_subtitle}**")
                 st.caption(
                     f"ℹ️ Geometric mean metrics use concurrency levels: "
@@ -1953,6 +1966,11 @@ def render_competitive_analysis_section(df):
             if pc:
                 pc_str = ", ".join(pc) if isinstance(pc, list) else pc
                 dialog_subtitle += f" &nbsp;|&nbsp; Prefix Caching: **{pc_str}**"
+            turns_f = st.session_state.get("selected_turns_filter", [])
+            if turns_f and any(t > 1 for t in turns_f):
+                dialog_subtitle += (
+                    f" &nbsp;|&nbsp; Turns: **{', '.join(str(t) for t in turns_f)}**"
+                )
         st.markdown(
             f"**{baseline}** vs **{competitor}** &nbsp;|&nbsp; "
             f"**{ACCELERATOR}** &nbsp;|&nbsp; ISL/OSL: **{profile_short}**"
@@ -2373,6 +2391,11 @@ def render_competitive_analysis_section(df):
                                             else pc
                                         )
                                         tab_subtitle += f" | Prefix Caching: {pc_str}"
+                                    turns_f = st.session_state.get(
+                                        "selected_turns_filter", []
+                                    )
+                                    if turns_f and any(t > 1 for t in turns_f):
+                                        tab_subtitle += f" | Turns: {', '.join(str(t) for t in turns_f)}"
                                 st.markdown(
                                     f"**NVIDIA H200 GPU, ISL/OSL: {label}{tab_subtitle}**"
                                 )
@@ -3248,7 +3271,7 @@ Changes within ±{NEUTRAL_THRESHOLD_PCT:.0f} % are not counted as losses.<br><br
 
     @st.dialog("Version Comparison — Metric Details", width="large")
     def _show_hm_compare_dialog(
-        model, tp, accel, profile, cisl_osl, dset, sdec, pcache
+        model, tp, accel, profile, cisl_osl, dset, sdec, pcache, turns=1
     ):
         short_name = _short_model_name(model)
         profile_display = _display_profile(profile, cisl_osl)
@@ -3262,6 +3285,7 @@ Changes within ±{NEUTRAL_THRESHOLD_PCT:.0f} % are not counted as losses.<br><br
             & (df["dataset"] == dset)
             & (df["spec_decoding"] == sdec)
             & (df["prefix_caching"] == pcache)
+            & (df["turns"] == turns)
         )
         df_v1 = df[mask_common & (df["version"] == ov_current)]
         df_v2 = df[mask_common & (df["version"] == ov_previous)]
@@ -3468,6 +3492,7 @@ Changes within ±{NEUTRAL_THRESHOLD_PCT:.0f} % are not counted as losses.<br><br
                 r.get("dataset", ""),
                 r.get("spec_decoding", ""),
                 r.get("prefix_caching", ""),
+                r.get("turns", 1),
             )
             if key not in seen:
                 seen[key] = r
@@ -3496,7 +3521,7 @@ Changes within ±{NEUTRAL_THRESHOLD_PCT:.0f} % are not counted as losses.<br><br
         # Data rows
         _n_rows = len(seen)
         for i, (
-            (_model_key, tp, profile, cisl_osl, _dset, _sdec, _pcache),
+            (_model_key, tp, profile, cisl_osl, _dset, _sdec, _pc, _turns),
             r,
         ) in enumerate(seen.items()):
             sname = r["short_name"]
@@ -3533,7 +3558,8 @@ Changes within ±{NEUTRAL_THRESHOLD_PCT:.0f} % are not counted as losses.<br><br
                         cisl_osl,
                         _dset,
                         _sdec,
-                        _pcache,
+                        _pc,
+                        _turns,
                     )
 
     st.markdown("---")
@@ -3548,7 +3574,7 @@ Changes within ±{NEUTRAL_THRESHOLD_PCT:.0f} % are not counted as losses.<br><br
         name = _short_model_name(entry["model"])
         config_parts = [
             f"{ver} · {_accel_display(accel)} · {_display_profile(prof, cisl)}"
-            for ver, accel, prof, cisl, _dset, _sdec, _pc in entry["configs"]
+            for ver, accel, prof, cisl, _dset, _sdec, _pc, _turns in entry["configs"]
         ]
         config_str = (
             f' <span style="opacity:0.7">({", ".join(config_parts)})</span>'
@@ -3742,6 +3768,10 @@ def render_performance_plots_section(filtered_df, use_expander=True):
         if filtered_df["prefix_caching"].any():
             filtered_df["run_identifier"] += filtered_df["prefix_caching"].apply(
                 lambda x: f" | PC={x}" if x else ""
+            )
+        if (filtered_df["turns"] > 1).any():
+            filtered_df["run_identifier"] += filtered_df["turns"].apply(
+                lambda x: f" | {x}T" if x > 1 else ""
             )
 
         _sort_cols = ["model_short", "accelerator", "version", "TP"]
@@ -5760,6 +5790,66 @@ def render_compare_versions_summary_section(df, use_expander=True):
         compare_dataset_filter = None
         compare_spec_decoding_filter = None
         compare_prefix_caching_filter = None
+        compare_turns_filter = None
+        compare_mt_isl_osl = None
+        compare_mt_turns = None
+        compare_mt_prefix_tokens = None
+        compare_mt_prefix_count = None
+        if selected_profile == "Multi-turn":
+            mt_temp = df[
+                (df["profile"] == "Multi-turn")
+                & (df["accelerator"].isin(available_accelerators))
+            ]
+            mt_pairs = sorted(p for p in mt_temp["multiturn_isl_osl"].unique() if p)
+            if mt_pairs:
+                compare_mt_isl_osl = st.selectbox(
+                    "Select ISL/OSL",
+                    options=mt_pairs,
+                    key="compare_summary_mt_isl_osl",
+                    on_change=keep_expander_open,
+                    args=("compare_versions_summary_expanded",),
+                )
+                mt_scoped = mt_temp[mt_temp["multiturn_isl_osl"] == compare_mt_isl_osl]
+                cmp_mt_turns_opts = sorted(mt_scoped["turns"].unique().tolist())
+                if cmp_mt_turns_opts:
+                    compare_mt_turns = st.multiselect(
+                        "Turns",
+                        cmp_mt_turns_opts,
+                        default=cmp_mt_turns_opts,
+                        key="compare_summary_mt_turns",
+                        on_change=keep_expander_open,
+                        args=("compare_versions_summary_expanded",),
+                    )
+                pt_scoped = mt_scoped
+                if compare_mt_turns:
+                    pt_scoped = pt_scoped[pt_scoped["turns"].isin(compare_mt_turns)]
+                cmp_pt_opts = sorted(
+                    v for v in pt_scoped["prefix_tokens"].unique() if v
+                )
+                if cmp_pt_opts:
+                    compare_mt_prefix_tokens = st.multiselect(
+                        "Prefix Tokens",
+                        cmp_pt_opts,
+                        default=cmp_pt_opts,
+                        key="compare_summary_mt_prefix_tokens",
+                        on_change=keep_expander_open,
+                        args=("compare_versions_summary_expanded",),
+                    )
+                pc_scoped = pt_scoped
+                if compare_mt_prefix_tokens:
+                    pc_scoped = pc_scoped[
+                        pc_scoped["prefix_tokens"].isin(compare_mt_prefix_tokens)
+                    ]
+                cmp_pc_opts = sorted(v for v in pc_scoped["prefix_count"].unique() if v)
+                if cmp_pc_opts:
+                    compare_mt_prefix_count = st.multiselect(
+                        "Prefix Count",
+                        cmp_pc_opts,
+                        default=cmp_pc_opts,
+                        key="compare_summary_mt_prefix_count",
+                        on_change=keep_expander_open,
+                        args=("compare_versions_summary_expanded",),
+                    )
         if selected_profile == "Custom" and "custom_isl_osl" in df.columns:
             custom_temp = df[
                 (df["profile"] == "Custom")
@@ -5830,6 +5920,36 @@ def render_compare_versions_summary_section(df, use_expander=True):
                                 args=("compare_versions_summary_expanded",),
                             )
 
+                        # Turns filter — scoped to dataset + spec_decoding + prefix_caching
+                        cmp_turns_temp = real_temp[
+                            real_temp["dataset"] == compare_dataset_filter
+                        ]
+                        if compare_spec_decoding_filter:
+                            cmp_turns_temp = cmp_turns_temp[
+                                cmp_turns_temp["spec_decoding"].isin(
+                                    compare_spec_decoding_filter
+                                )
+                            ]
+                        if compare_prefix_caching_filter:
+                            cmp_turns_temp = cmp_turns_temp[
+                                cmp_turns_temp["prefix_caching"].isin(
+                                    compare_prefix_caching_filter
+                                )
+                            ]
+                        cmp_turns_options = sorted(
+                            cmp_turns_temp["turns"].unique().tolist()
+                        )
+                        if len(cmp_turns_options) > 1:
+                            compare_turns_filter = st.multiselect(
+                                "Turns",
+                                cmp_turns_options,
+                                default=cmp_turns_options,
+                                format_func=lambda x: str(x),
+                                key="compare_summary_turns",
+                                on_change=keep_expander_open,
+                                args=("compare_versions_summary_expanded",),
+                            )
+
         if not version_2:
             st.warning("⚠️ Please select a second version to compare.")
             return
@@ -5864,6 +5984,33 @@ def render_compare_versions_summary_section(df, use_expander=True):
             )
             base_mask_v2 = base_mask_v2 & df["prefix_caching"].isin(
                 compare_prefix_caching_filter
+            )
+        if compare_turns_filter:
+            base_mask_v1 = base_mask_v1 & df["turns"].isin(compare_turns_filter)
+            base_mask_v2 = base_mask_v2 & df["turns"].isin(compare_turns_filter)
+        if compare_mt_isl_osl:
+            base_mask_v1 = base_mask_v1 & (
+                df["multiturn_isl_osl"] == compare_mt_isl_osl
+            )
+            base_mask_v2 = base_mask_v2 & (
+                df["multiturn_isl_osl"] == compare_mt_isl_osl
+            )
+        if compare_mt_turns:
+            base_mask_v1 = base_mask_v1 & df["turns"].isin(compare_mt_turns)
+            base_mask_v2 = base_mask_v2 & df["turns"].isin(compare_mt_turns)
+        if compare_mt_prefix_tokens:
+            base_mask_v1 = base_mask_v1 & df["prefix_tokens"].isin(
+                compare_mt_prefix_tokens
+            )
+            base_mask_v2 = base_mask_v2 & df["prefix_tokens"].isin(
+                compare_mt_prefix_tokens
+            )
+        if compare_mt_prefix_count:
+            base_mask_v1 = base_mask_v1 & df["prefix_count"].isin(
+                compare_mt_prefix_count
+            )
+            base_mask_v2 = base_mask_v2 & df["prefix_count"].isin(
+                compare_mt_prefix_count
             )
         df_v1 = df[base_mask_v1].copy()
         df_v2 = df[base_mask_v2].copy()
@@ -6751,7 +6898,7 @@ def render_compare_configurations_section(
             "💡 **Compare performance between two configurations across all versions and metrics.**"
         )
 
-        _cfg_cols = ["model", "dataset", "spec_decoding", "prefix_caching"]
+        _cfg_cols = ["model", "dataset", "spec_decoding", "prefix_caching", "turns"]
         _cfg_df = (
             filtered_df[_cfg_cols]
             .fillna("")
@@ -6769,6 +6916,8 @@ def render_compare_configurations_section(
                 parts.append(f"SD={row['spec_decoding']}")
             if row["prefix_caching"]:
                 parts.append(f"PC={row['prefix_caching']}")
+            if row["turns"] > 1:
+                parts.append(f"{row['turns']}T")
             return " | ".join(parts)
 
         _cfg_df["_label"] = _cfg_df.apply(_cfg_label, axis=1)
@@ -6779,6 +6928,7 @@ def render_compare_configurations_section(
                 row["dataset"],
                 row["spec_decoding"],
                 row["prefix_caching"],
+                row["turns"],
             )
             for _, row in _cfg_df.iterrows()
         }
@@ -6822,11 +6972,12 @@ def render_compare_configurations_section(
             return
 
         def _filter_by_config(src_df, cfg_tuple):
-            model, dataset, spec_dec, pref_cache = cfg_tuple
+            model, dataset, spec_dec, pref_cache, turns = cfg_tuple
             mask = src_df["model"] == model
             mask &= src_df["dataset"].fillna("") == dataset
             mask &= src_df["spec_decoding"].fillna("") == spec_dec
             mask &= src_df["prefix_caching"].fillna("") == pref_cache
+            mask &= src_df["turns"] == turns
             return src_df[mask].copy()
 
         cfg1_tuple = label_to_tuple[config_1]
@@ -10982,6 +11133,10 @@ def main():
             if "custom_isl_osl" in query_params:
                 url_custom_isl_osl = query_params["custom_isl_osl"].strip()
 
+            url_multiturn_isl_osl = None
+            if "multiturn_isl_osl" in query_params:
+                url_multiturn_isl_osl = query_params["multiturn_isl_osl"].strip()
+
             url_dp_sizes = []
             if "dp_sizes" in query_params:
                 try:
@@ -11044,12 +11199,25 @@ def main():
                 url_section_filters,
                 url_custom_isl_osl,
                 url_dp_sizes,
+                url_multiturn_isl_osl,
             )
 
     df["profile"] = assign_profile_vectorized(df)
 
+    # Override profile for multiturn data (turns > 1)
+    if "turns" in df.columns:
+        df.loc[df["turns"].fillna(1).astype(int) > 1, "profile"] = "Multi-turn"
+
     df["custom_isl_osl"] = np.where(
         df["profile"] == "Custom",
+        df["prompt toks"].astype(int).astype(str)
+        + "/"
+        + df["output toks"].astype(int).astype(str),
+        "",
+    )
+
+    df["multiturn_isl_osl"] = np.where(
+        df["profile"] == "Multi-turn",
         df["prompt toks"].astype(int).astype(str)
         + "/"
         + df["output toks"].astype(int).astype(str),
@@ -11065,6 +11233,34 @@ def main():
     if "prefix_caching" not in df.columns:
         df["prefix_caching"] = ""
     df["prefix_caching"] = df["prefix_caching"].fillna("").astype(str)
+
+    if "turns" not in df.columns:
+        df["turns"] = 1
+    df["turns"] = df["turns"].fillna(1).astype(int)
+
+    if "prefix_tokens" not in df.columns:
+        df["prefix_tokens"] = ""
+    df["prefix_tokens"] = (
+        df["prefix_tokens"]
+        .fillna("")
+        .apply(
+            lambda v: (
+                str(int(float(v))) if v != "" and str(v) not in ("", "nan") else ""
+            )
+        )
+    )
+
+    if "prefix_count" not in df.columns:
+        df["prefix_count"] = ""
+    df["prefix_count"] = (
+        df["prefix_count"]
+        .fillna("")
+        .apply(
+            lambda v: (
+                str(int(float(v))) if v != "" and str(v) not in ("", "nan") else ""
+            )
+        )
+    )
 
     df["error_rate"] = (
         df["errored_requests"]
@@ -11093,6 +11289,7 @@ def main():
             url_section_filters,
             url_custom_isl_osl,
             url_dp_sizes,
+            url_multiturn_isl_osl,
         ) = decode_filters_from_url()
 
         if url_section:
@@ -11171,6 +11368,8 @@ def main():
         st.session_state.use_url_filters = has_url_filters
         if url_custom_isl_osl:
             st.session_state.selected_custom_isl_osl = url_custom_isl_osl
+        if url_multiturn_isl_osl:
+            st.session_state.selected_multiturn_isl_osl = url_multiturn_isl_osl
 
     SECTIONS_WITHOUT_GLOBAL_FILTERS = {
         "🏠 Overview",
@@ -11220,9 +11419,12 @@ def main():
             # If no profile selected yet, determine the default that will be selected
             if not current_profile:
                 available_profiles_raw = sorted(df["profile"].unique().tolist())
-                available_profiles = [
-                    p for p in available_profiles_raw if p != "Custom"
-                ] + (["Custom"] if "Custom" in available_profiles_raw else [])
+                _sp = ("Multi-turn", "Custom")
+                available_profiles = (
+                    [p for p in available_profiles_raw if p not in _sp]
+                    + (["Multi-turn"] if "Multi-turn" in available_profiles_raw else [])
+                    + (["Custom"] if "Custom" in available_profiles_raw else [])
+                )
 
                 # Default to Profile A (1k/1k) when clearing or as fallback
                 default_profile = "Profile A: Balanced (1k/1k)"
@@ -11320,9 +11522,12 @@ def main():
                 if not temp_df.empty
                 else []
             )
-            # Sort so "Custom" always comes last to avoid it being picked as profiles[0] fallback
-            profiles = [p for p in profiles_raw if p != "Custom"] + (
-                ["Custom"] if "Custom" in profiles_raw else []
+            # Sort so "Multi-turn" and "Custom" always come last
+            _special = ("Multi-turn", "Custom")
+            profiles = (
+                [p for p in profiles_raw if p not in _special]
+                + (["Multi-turn"] if "Multi-turn" in profiles_raw else [])
+                + (["Custom"] if "Custom" in profiles_raw else [])
             )
 
             # Default to Profile A (1k/1k) when clearing or as fallback
@@ -11503,6 +11708,89 @@ def main():
                             selected_prefix_caching_filter
                         )
 
+            # ── Multi-turn cascading filters ──
+            selected_multiturn_isl_osl = None
+            selected_mt_turns = None
+            selected_mt_prefix_tokens = None
+            selected_mt_prefix_count = None
+
+            if selected_profile == "Multi-turn":
+                mt_temp = df.copy()
+                if selected_accelerators:
+                    mt_temp = mt_temp[
+                        mt_temp["accelerator"].isin(selected_accelerators)
+                    ]
+                mt_temp = mt_temp[mt_temp["profile"] == "Multi-turn"]
+
+                # ISL/OSL pair selector
+                mt_pairs = sorted(mt_temp["multiturn_isl_osl"].unique().tolist())
+                mt_pairs = [p for p in mt_pairs if p]
+                if mt_pairs:
+                    mt_isl_key = (
+                        f"mt_isl_osl_filter_{st.session_state.filter_change_key}"
+                    )
+                    if mt_isl_key not in st.session_state:
+                        url_mt = st.session_state.get("selected_multiturn_isl_osl")
+                        st.session_state[mt_isl_key] = (
+                            url_mt if url_mt and url_mt in mt_pairs else mt_pairs[0]
+                        )
+                    elif st.session_state.get(mt_isl_key) not in mt_pairs:
+                        st.session_state[mt_isl_key] = mt_pairs[0]
+                    selected_multiturn_isl_osl = st.selectbox(
+                        "Select ISL/OSL",
+                        mt_pairs,
+                        key=mt_isl_key,
+                    )
+                    st.session_state.selected_multiturn_isl_osl = (
+                        selected_multiturn_isl_osl
+                    )
+
+                    # Turns filter — scoped to selected ISL/OSL
+                    turns_temp = mt_temp[
+                        mt_temp["multiturn_isl_osl"] == selected_multiturn_isl_osl
+                    ]
+                    turns_opts = sorted(turns_temp["turns"].unique().tolist())
+                    if turns_opts:
+                        turns_key = (
+                            f"mt_turns_filter_{st.session_state.filter_change_key}"
+                        )
+                        selected_mt_turns = st.multiselect(
+                            "Turns",
+                            turns_opts,
+                            default=turns_opts,
+                            key=turns_key,
+                        )
+
+                    # Prefix tokens filter — scoped to ISL/OSL + turns
+                    pt_temp = turns_temp
+                    if selected_mt_turns:
+                        pt_temp = pt_temp[pt_temp["turns"].isin(selected_mt_turns)]
+                    pt_opts = sorted(v for v in pt_temp["prefix_tokens"].unique() if v)
+                    if pt_opts:
+                        pt_key = f"mt_prefix_tokens_filter_{st.session_state.filter_change_key}"
+                        selected_mt_prefix_tokens = st.multiselect(
+                            "Prefix Tokens",
+                            pt_opts,
+                            default=pt_opts,
+                            key=pt_key,
+                        )
+
+                    # Prefix count filter — scoped to ISL/OSL + turns + prefix_tokens
+                    pc_temp = pt_temp
+                    if selected_mt_prefix_tokens:
+                        pc_temp = pc_temp[
+                            pc_temp["prefix_tokens"].isin(selected_mt_prefix_tokens)
+                        ]
+                    pc_opts = sorted(v for v in pc_temp["prefix_count"].unique() if v)
+                    if pc_opts:
+                        pc_mt_key = f"mt_prefix_count_filter_{st.session_state.filter_change_key}"
+                        selected_mt_prefix_count = st.multiselect(
+                            "Prefix Count",
+                            pc_opts,
+                            default=pc_opts,
+                            key=pc_mt_key,
+                        )
+
             # Update baseline_profile to remember user's current selection
             # This ensures the selected profile is retained when other filters change
             if selected_profile is not None:
@@ -11535,6 +11823,21 @@ def main():
             if selected_prefix_caching_filter:
                 temp_df = temp_df[
                     temp_df["prefix_caching"].isin(selected_prefix_caching_filter)
+                ]
+            # Narrow to multi-turn filters
+            if selected_multiturn_isl_osl:
+                temp_df = temp_df[
+                    temp_df["multiturn_isl_osl"] == selected_multiturn_isl_osl
+                ]
+            if selected_mt_turns:
+                temp_df = temp_df[temp_df["turns"].isin(selected_mt_turns)]
+            if selected_mt_prefix_tokens:
+                temp_df = temp_df[
+                    temp_df["prefix_tokens"].isin(selected_mt_prefix_tokens)
+                ]
+            if selected_mt_prefix_count:
+                temp_df = temp_df[
+                    temp_df["prefix_count"].isin(selected_mt_prefix_count)
                 ]
 
             versions = (
@@ -11705,6 +12008,21 @@ def main():
             if selected_prefix_caching_filter:
                 temp_df = temp_df[
                     temp_df["prefix_caching"].isin(selected_prefix_caching_filter)
+                ]
+            # Narrow to multi-turn filters
+            if selected_multiturn_isl_osl:
+                temp_df = temp_df[
+                    temp_df["multiturn_isl_osl"] == selected_multiturn_isl_osl
+                ]
+            if selected_mt_turns:
+                temp_df = temp_df[temp_df["turns"].isin(selected_mt_turns)]
+            if selected_mt_prefix_tokens:
+                temp_df = temp_df[
+                    temp_df["prefix_tokens"].isin(selected_mt_prefix_tokens)
+                ]
+            if selected_mt_prefix_count:
+                temp_df = temp_df[
+                    temp_df["prefix_count"].isin(selected_mt_prefix_count)
                 ]
 
             models = (
@@ -11899,6 +12217,25 @@ def main():
             if selected_prefix_caching_filter
             else True
         )
+        # Multi-turn masks
+        multiturn_isl_osl_mask = (
+            (df["multiturn_isl_osl"] == selected_multiturn_isl_osl)
+            if selected_profile == "Multi-turn" and selected_multiturn_isl_osl
+            else True
+        )
+        mt_turns_mask = (
+            df["turns"].isin(selected_mt_turns) if selected_mt_turns else True
+        )
+        mt_prefix_tokens_mask = (
+            df["prefix_tokens"].isin(selected_mt_prefix_tokens)
+            if selected_mt_prefix_tokens
+            else True
+        )
+        mt_prefix_count_mask = (
+            df["prefix_count"].isin(selected_mt_prefix_count)
+            if selected_mt_prefix_count
+            else True
+        )
         tp_mask = df["TP"].isin(selected_tp) | df["TP"].isna()
         filtered_df = df[
             df["accelerator"].isin(selected_accelerators)
@@ -11910,6 +12247,10 @@ def main():
             & dataset_mask
             & spec_decoding_mask
             & prefix_caching_mask
+            & multiturn_isl_osl_mask
+            & mt_turns_mask
+            & mt_prefix_tokens_mask
+            & mt_prefix_count_mask
             & dp_mask
         ].copy()
 
@@ -12113,6 +12454,10 @@ def main():
                 custom_val = st.session_state.get("selected_custom_isl_osl")
                 if custom_val:
                     desired_params["custom_isl_osl"] = custom_val
+            if selected_profile == "Multi-turn":
+                mt_val = st.session_state.get("selected_multiturn_isl_osl")
+                if mt_val:
+                    desired_params["multiturn_isl_osl"] = mt_val
             if selected_tp:
                 desired_params["tp_sizes"] = ",".join(map(str, selected_tp))
             if st.session_state.get("show_advanced_filters", False) and selected_dp:

--- a/manual_runs/scripts/README.md
+++ b/manual_runs/scripts/README.md
@@ -46,7 +46,6 @@ python import_manual_runs_json_v2.py <json_file> \
 | `--dataset`          | No       | Real dataset name (for real-dataset runs)       | `mlperf-gpt-oss`, `sharegpt`            |
 | `--spec-decoding`    | No       | Speculative decoding method used                | `eagle3`, `ngram`                       |
 | `--prefix-caching`   | No       | Whether prefix caching was enabled              | `yes`, `no`                             |
-| `--turns`            | No       | Number of conversation turns (multiturn)        | `5`, `10`                               |
 
 ## Examples
 
@@ -110,11 +109,10 @@ python import_manual_runs_json_v2.py \
   --runtime-args "tp: 1" \
   --image-tag "v0.19.1" \
   --guidellm-version "0.6.0" \
-  --turns 5 \
   --csv-file "gemma-multiturn.csv"
 ```
 
-> **Note:** `turns`, `prefix_tokens`, `prefix_count`, and `request_type` are auto-detected from the guidellm JSON when available. The `--turns` flag overrides auto-detection.
+> **Note:** `turns`, `prefix_tokens`, `prefix_count`, and `request_type` are auto-detected from the guidellm JSON.
 
 ## Appending to Consolidated Dashboard
 

--- a/manual_runs/scripts/README.md
+++ b/manual_runs/scripts/README.md
@@ -174,14 +174,14 @@ The script outputs 52 columns compatible with the performance dashboard:
 | 42  | `guidellm_end_time_ms`    | Benchmark end time (epoch ms)                        |
 | 43  | `image_tag`               | Container image used                                 |
 | 44  | `guidellm_version`        | guidellm version used                                |
-| 45  | `request_type`            | GuideLLM API endpoint type (auto-detected from JSON) |
-| 46  | `DP`                      | Data parallelism size (empty for TP runs)            |
-| 47  | `dataset`                 | Real dataset name (empty for synthetic runs)         |
-| 48  | `spec_decoding`           | Speculative decoding method (empty if none)          |
-| 49  | `prefix_caching`          | Prefix caching status (`yes`, `no`, or empty)        |
-| 50  | `turns`                   | Conversation turns for multiturn benchmarks          |
-| 51  | `prefix_tokens`           | Prefix token count (auto-detected from JSON)         |
-| 52  | `prefix_count`            | Prefix count (auto-detected from JSON)               |
+| 45  | `DP`                      | Data parallelism size (empty for TP runs)            |
+| 46  | `dataset`                 | Real dataset name (empty for synthetic runs)         |
+| 47  | `spec_decoding`           | Speculative decoding method (empty if none)          |
+| 48  | `prefix_caching`          | Prefix caching status (`yes`, `no`, or empty)        |
+| 49  | `turns`                   | Conversation turns for multiturn benchmarks          |
+| 50  | `prefix_tokens`           | Prefix token count (auto-detected from JSON)         |
+| 51  | `prefix_count`            | Prefix count (auto-detected from JSON)               |
+| 52  | `request_type`            | GuideLLM API endpoint type (auto-detected from JSON) |
 
 ## Notes
 

--- a/manual_runs/scripts/README.md
+++ b/manual_runs/scripts/README.md
@@ -46,6 +46,7 @@ python import_manual_runs_json_v2.py <json_file> \
 | `--dataset`          | No       | Real dataset name (for real-dataset runs)       | `mlperf-gpt-oss`, `sharegpt`            |
 | `--spec-decoding`    | No       | Speculative decoding method used                | `eagle3`, `ngram`                       |
 | `--prefix-caching`   | No       | Whether prefix caching was enabled              | `yes`, `no`                             |
+| `--turns`            | No       | Number of conversation turns (multiturn)        | `5`, `10`                               |
 
 ## Examples
 
@@ -97,6 +98,24 @@ python import_manual_runs_json_v2.py \
   --csv-file "gpt-oss-120b-sd-pc.csv"
 ```
 
+### Multiturn Benchmark
+
+```bash
+python import_manual_runs_json_v2.py \
+  multiturn-gemma.json \
+  --model "google/gemma-4-31B-it" \
+  --version "vLLM-0.19.1" \
+  --tp 1 \
+  --accelerator "H200" \
+  --runtime-args "tp: 1" \
+  --image-tag "v0.19.1" \
+  --guidellm-version "0.6.0" \
+  --turns 5 \
+  --csv-file "gemma-multiturn.csv"
+```
+
+> **Note:** `turns`, `prefix_tokens`, `prefix_count`, and `request_type` are auto-detected from the guidellm JSON when available. The `--turns` flag overrides auto-detection.
+
 ## Appending to Consolidated Dashboard
 
 After generating a CSV file, append it to the main dashboard (skip the header):
@@ -107,7 +126,7 @@ tail -n +2 my-benchmark.csv >> ../consolidated_dashboard.csv
 
 ## Output CSV Columns
 
-The script outputs 47 columns compatible with the performance dashboard:
+The script outputs 52 columns compatible with the performance dashboard:
 
 | #   | Column                    | Description                                          |
 | --- | ------------------------- | ---------------------------------------------------- |
@@ -155,9 +174,14 @@ The script outputs 47 columns compatible with the performance dashboard:
 | 42  | `guidellm_end_time_ms`    | Benchmark end time (epoch ms)                        |
 | 43  | `image_tag`               | Container image used                                 |
 | 44  | `guidellm_version`        | guidellm version used                                |
-| 45  | `dataset`                 | Real dataset name (empty for synthetic runs)         |
-| 46  | `spec_decoding`           | Speculative decoding method (empty if none)          |
-| 47  | `prefix_caching`          | Prefix caching status (`yes`, `no`, or empty)        |
+| 45  | `request_type`            | GuideLLM API endpoint type (auto-detected from JSON) |
+| 46  | `DP`                      | Data parallelism size (empty for TP runs)            |
+| 47  | `dataset`                 | Real dataset name (empty for synthetic runs)         |
+| 48  | `spec_decoding`           | Speculative decoding method (empty if none)          |
+| 49  | `prefix_caching`          | Prefix caching status (`yes`, `no`, or empty)        |
+| 50  | `turns`                   | Conversation turns for multiturn benchmarks          |
+| 51  | `prefix_tokens`           | Prefix token count (auto-detected from JSON)         |
+| 52  | `prefix_count`            | Prefix count (auto-detected from JSON)               |
 
 ## Notes
 

--- a/manual_runs/scripts/import_manual_runs_json_v2.py
+++ b/manual_runs/scripts/import_manual_runs_json_v2.py
@@ -522,7 +522,6 @@ def main():
             "guidellm_end_time_ms",
             "image_tag",
             "guidellm_version",
-            "request_type",
             "DP",
             "dataset",
             "spec_decoding",
@@ -530,6 +529,7 @@ def main():
             "turns",
             "prefix_tokens",
             "prefix_count",
+            "request_type",
         ]
 
         for col in fieldnames:

--- a/manual_runs/scripts/import_manual_runs_json_v2.py
+++ b/manual_runs/scripts/import_manual_runs_json_v2.py
@@ -31,6 +31,7 @@ def process_benchmark_section(
     spec_decoding="",
     prefix_caching="",
     turns=None,
+    request_type="",
 ):
     """Process a single benchmark section and extract performance metrics.
 
@@ -220,6 +221,7 @@ def process_benchmark_section(
         "turns": turns,
         "prefix_tokens": detected_prefix_tokens if detected_prefix_tokens else "",
         "prefix_count": detected_prefix_count if detected_prefix_count else "",
+        "request_type": request_type,
     }
 
     return row
@@ -289,6 +291,8 @@ def parse_guidellm_json(
     # Get global data config (prompt_tokens, output_tokens)
     global_args = data.get("args", {})
     global_data_config = global_args.get("data", [])
+    backend_kwargs = global_args.get("backend_kwargs", {})
+    request_type = backend_kwargs.get("request_format", "")
 
     # Extract aggregated guidellm start and end times from scheduler_metrics
     start_times = []
@@ -324,6 +328,7 @@ def parse_guidellm_json(
             dataset=dataset,
             spec_decoding=spec_decoding,
             prefix_caching=prefix_caching,
+            request_type=request_type,
         )
         if row_data:
             all_run_data.append(row_data)
@@ -507,6 +512,7 @@ def main():
             "guidellm_end_time_ms",
             "image_tag",
             "guidellm_version",
+            "request_type",
             "DP",
             "dataset",
             "spec_decoding",

--- a/manual_runs/scripts/import_manual_runs_json_v2.py
+++ b/manual_runs/scripts/import_manual_runs_json_v2.py
@@ -30,6 +30,7 @@ def process_benchmark_section(
     dataset="",
     spec_decoding="",
     prefix_caching="",
+    turns=None,
 ):
     """Process a single benchmark section and extract performance metrics.
 
@@ -50,6 +51,7 @@ def process_benchmark_section(
         dataset: Dataset name for real-dataset runs (e.g., 'gpt-oss', 'sharegpt').
         spec_decoding: Speculative decoding method (e.g., 'eagle3').
         prefix_caching: Whether prefix caching is enabled ('yes', 'no', or '').
+        turns: Number of conversation turns for multiturn benchmarks (default: 1).
 
     Returns:
         dict: Processed benchmark metrics.
@@ -74,6 +76,9 @@ def process_benchmark_section(
     # Format can be either JSON or key=value pairs like "prompt_tokens=1000,output_tokens=1000"
     config_prompt_tokens = 0
     config_output_tokens = 0
+    detected_turns = None
+    detected_prefix_tokens = None
+    detected_prefix_count = None
     try:
         if global_data_config and len(global_data_config) > 0:
             data_str = global_data_config[0]
@@ -82,8 +87,16 @@ def process_benchmark_section(
                 request_config = json.loads(data_str)
                 config_prompt_tokens = request_config.get("prompt_tokens", 0)
                 config_output_tokens = request_config.get("output_tokens", 0)
+                if "turns" in request_config:
+                    _t = int(request_config["turns"])
+                    if _t >= 1:
+                        detected_turns = _t
+                if "prefix_tokens" in request_config:
+                    detected_prefix_tokens = int(request_config["prefix_tokens"])
+                if "prefix_count" in request_config:
+                    detected_prefix_count = int(request_config["prefix_count"])
             except json.JSONDecodeError:
-                # Try key=value format: "prompt_tokens=1000,output_tokens=1000"
+                # Try key=value format: "prompt_tokens=1000,output_tokens=1000,turns=3"
                 for item in data_str.split(","):
                     if "=" in item:
                         key, value = item.strip().split("=", 1)
@@ -91,9 +104,29 @@ def process_benchmark_section(
                             config_prompt_tokens = int(value)
                         elif key == "output_tokens":
                             config_output_tokens = int(value)
+                        elif key == "turns":
+                            _t = int(value)
+                            if _t >= 1:
+                                detected_turns = _t
+                        elif key == "prefix_tokens":
+                            detected_prefix_tokens = int(value)
+                        elif key == "prefix_count":
+                            detected_prefix_count = int(value)
     except (KeyError, TypeError, ValueError):
         config_prompt_tokens = 0
         config_output_tokens = 0
+
+    # Resolve turns: CLI override > auto-detected > default 1
+    if turns is not None:
+        # Explicitly provided via CLI — use as-is
+        pass
+    elif detected_turns is not None:
+        turns = detected_turns
+    else:
+        turns = 1
+
+    if turns < 1:
+        raise ValueError(f"turns must be >= 1, got {turns}")
 
     # Get request stats from scheduler_metrics
     scheduler_metrics = benchmark.get("scheduler_metrics", {})
@@ -184,6 +217,9 @@ def process_benchmark_section(
         "dataset": dataset,
         "spec_decoding": spec_decoding,
         "prefix_caching": prefix_caching,
+        "turns": turns,
+        "prefix_tokens": detected_prefix_tokens if detected_prefix_tokens else "",
+        "prefix_count": detected_prefix_count if detected_prefix_count else "",
     }
 
     return row
@@ -220,6 +256,7 @@ def parse_guidellm_json(
         dataset: Dataset name for real-dataset runs (e.g., 'gpt-oss', 'sharegpt').
         spec_decoding: Speculative decoding method (e.g., 'eagle3').
         prefix_caching: Whether prefix caching is enabled ('yes', 'no', or '').
+        turns: Number of conversation turns for multiturn benchmarks (default: 1).
 
     Returns:
         DataFrame: Processed benchmark results.
@@ -474,6 +511,9 @@ def main():
             "dataset",
             "spec_decoding",
             "prefix_caching",
+            "turns",
+            "prefix_tokens",
+            "prefix_count",
         ]
 
         for col in fieldnames:

--- a/manual_runs/scripts/import_manual_runs_json_v2.py
+++ b/manual_runs/scripts/import_manual_runs_json_v2.py
@@ -219,8 +219,12 @@ def process_benchmark_section(
         "spec_decoding": spec_decoding,
         "prefix_caching": prefix_caching,
         "turns": turns,
-        "prefix_tokens": detected_prefix_tokens if detected_prefix_tokens else "",
-        "prefix_count": detected_prefix_count if detected_prefix_count else "",
+        "prefix_tokens": detected_prefix_tokens
+        if detected_prefix_tokens is not None
+        else "",
+        "prefix_count": detected_prefix_count
+        if detected_prefix_count is not None
+        else "",
         "request_type": request_type,
     }
 
@@ -258,7 +262,6 @@ def parse_guidellm_json(
         dataset: Dataset name for real-dataset runs (e.g., 'gpt-oss', 'sharegpt').
         spec_decoding: Speculative decoding method (e.g., 'eagle3').
         prefix_caching: Whether prefix caching is enabled ('yes', 'no', or '').
-        turns: Number of conversation turns for multiturn benchmarks (default: 1).
 
     Returns:
         DataFrame: Processed benchmark results.

--- a/manual_runs/scripts/import_manual_runs_json_v2.py
+++ b/manual_runs/scripts/import_manual_runs_json_v2.py
@@ -30,7 +30,6 @@ def process_benchmark_section(
     dataset="",
     spec_decoding="",
     prefix_caching="",
-    turns=None,
     request_type="",
 ):
     """Process a single benchmark section and extract performance metrics.
@@ -52,7 +51,6 @@ def process_benchmark_section(
         dataset: Dataset name for real-dataset runs (e.g., 'gpt-oss', 'sharegpt').
         spec_decoding: Speculative decoding method (e.g., 'eagle3').
         prefix_caching: Whether prefix caching is enabled ('yes', 'no', or '').
-        turns: Number of conversation turns for multiturn benchmarks (default: 1).
         request_type: GuideLLM API endpoint type (e.g., 'chat_completions', 'completions').
 
     Returns:
@@ -118,17 +116,8 @@ def process_benchmark_section(
         config_prompt_tokens = 0
         config_output_tokens = 0
 
-    # Resolve turns: CLI override > auto-detected > default 1
-    if turns is not None:
-        # Explicitly provided via CLI — use as-is
-        pass
-    elif detected_turns is not None:
-        turns = detected_turns
-    else:
-        turns = 1
-
-    if turns < 1:
-        raise ValueError(f"turns must be >= 1, got {turns}")
+    # Resolve turns from auto-detection, default to 1
+    turns = detected_turns if detected_turns is not None else 1
 
     # Get request stats from scheduler_metrics
     scheduler_metrics = benchmark.get("scheduler_metrics", {})

--- a/manual_runs/scripts/import_manual_runs_json_v2.py
+++ b/manual_runs/scripts/import_manual_runs_json_v2.py
@@ -53,6 +53,7 @@ def process_benchmark_section(
         spec_decoding: Speculative decoding method (e.g., 'eagle3').
         prefix_caching: Whether prefix caching is enabled ('yes', 'no', or '').
         turns: Number of conversation turns for multiturn benchmarks (default: 1).
+        request_type: GuideLLM API endpoint type (e.g., 'chat_completions', 'completions').
 
     Returns:
         dict: Processed benchmark metrics.
@@ -262,6 +263,12 @@ def parse_guidellm_json(
         dataset: Dataset name for real-dataset runs (e.g., 'gpt-oss', 'sharegpt').
         spec_decoding: Speculative decoding method (e.g., 'eagle3').
         prefix_caching: Whether prefix caching is enabled ('yes', 'no', or '').
+
+    Auto-detected from JSON:
+        turns: Number of conversation turns (from args.data config).
+        prefix_tokens: Prefix token count (from args.data config).
+        prefix_count: Prefix count (from args.data config).
+        request_type: API endpoint type (from args.backend_kwargs.request_format).
 
     Returns:
         DataFrame: Processed benchmark results.


### PR DESCRIPTION
## Summary
- Add multiturn benchmark support with composite filters (turns, prefix_tokens, prefix_count)
- Extract `request_format` from `args.backend_kwargs` in guidellm JSON as `request_type` column
- Show `request_type` in Filtered Data after `version`; backward compatible with old CSVs

### CodeRabbit fixes
- Fix `prefix_tokens`/`prefix_count` truthiness: use `is not None` so `0` is a valid value
- Remove orphaned `turns` param from `parse_guidellm_json` docstring
- Include prefix dimensions in multi-turn plot identifiers (e.g., `5T/512pt/10pc`)
- Fix empty multiselect showing all rows instead of none (`is not None` checks)
- Persist full multi-turn cascade (turns, prefix_tokens, prefix_count) in URL state
- Fix Compare Versions multi-turn filter masks

> **Note:** This is a clean rebase of #37 onto staging (3 files, 10 commits) — the original PR showed 26 files changed due to main-vs-staging divergence.

## Test plan
- [ ] Verify dashboard loads without errors
- [ ] Confirm multiturn filters (turns, prefix_tokens, prefix_count) work correctly
- [ ] Confirm request_type column appears in Filtered Data view
- [ ] Verify Compare Versions works with multi-turn dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)