### PR TITLE
Fix multi-turn traces merging when prefix_caching differs in runtime_args (main)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -11561,6 +11561,23 @@ def main():
         df["prefix_caching"] = ""
     df["prefix_caching"] = df["prefix_caching"].fillna("").astype(str)
 
+    # Derive prefix_caching from runtime_args when not explicitly set
+    if "runtime_args" in df.columns:
+        mask = (df["prefix_caching"] == "") & df["runtime_args"].notna()
+
+        def _extract_prefix_caching(args_str):
+            for part in str(args_str).split(";"):
+                part = part.strip()
+                if part.startswith("no-enable-prefix-caching:"):
+                    val = part.split(":", 1)[1].strip()
+                    # Double-negative: no-enable-prefix-caching: True means OFF
+                    return "no" if val.lower() == "true" else "yes"
+            return ""
+
+        df.loc[mask, "prefix_caching"] = df.loc[mask, "runtime_args"].apply(
+            _extract_prefix_caching
+        )
+
     if "turns" not in df.columns:
         df["turns"] = 1
     df["turns"] = df["turns"].fillna(1).astype(int)


### PR DESCRIPTION
## Summary
- Multi-turn benchmark data has `prefix_caching = NaN` even when runs differ in prefix caching config
- The differentiating info is in `runtime_args` (e.g., `no-enable-prefix-caching: True` vs `False`)
- This caused Performance Plots to merge distinct runs into a single zigzag trace

## Fix
After existing `prefix_caching` fillna/astype preprocessing, backfill empty values from `runtime_args`:
- `no-enable-prefix-caching: True` → `prefix_caching = "no"` (caching OFF)
- `no-enable-prefix-caching: False` → `prefix_caching = "yes"` (caching ON)

## Verification
Tested against staging CSV:
- **Before**: All 17 multi-turn rows had `prefix_caching = NaN`
- **After**: Rows correctly labeled `"no"` or `"yes"` based on `runtime_args`, producing separate trace keys

## Test plan
- [ ] Run `ruff check dashboard.py` — passes clean
- [ ] Load dashboard and verify multi-turn traces no longer merge into zigzag lines
- [ ] Verify single-turn rows (which already have `prefix_caching` set) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard data handling by filling in missing prefix-caching status from available runtime settings.
  * Correctly identifies whether prefix caching is enabled or disabled when the status is not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->