### PR TITLE
Add Profile E: Long Context (100k/1k) to profile mapping

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -461,12 +461,14 @@ def assign_profile_vectorized(df):
         (prompt == 512) & (output == 2048),
         (prompt == 2048) & (output == 128),
         (prompt == 8000) & (output == 1000),
+        (prompt == 100000) & (output == 1000),
     ]
     choices = [
         "Profile A: Balanced (1k/1k)",
         "Profile B: Variable Workload (512/2k)",
         "Profile C: Large Prompt (2k/128)",
         "Profile D: Prefill Heavy (8k/1k)",
+        "Profile E: Long Context (100k/1k)",
     ]
     return np.select(conditions, choices, default="Custom ISL/OSL")
 


### PR DESCRIPTION
## Summary
- `100000/1000` ISL/OSL pair now appears as **Profile E: Long Context (100k/1k)** in the profile dropdown
- Previously it fell under "Custom ISL/OSL" requiring an extra dropdown selection

## Change
Added one condition/choice to `assign_profile_vectorized()` — no other changes needed.

## Test plan
- [ ] `ruff check dashboard.py` passes
- [ ] Profile dropdown shows "Profile E: Long Context (100k/1k)" for 100k/1k data
- [ ] Existing profiles A-D unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing workloads with 100,000 prompt tokens and 1,000 output tokens.
  * These workloads now display the profile name “Profile E: Long Context (100k/1k)” instead of being classified as custom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->