### PR TITLE
Add SGLang Grafana dashboard routing for View Metrics links (staging)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -10699,7 +10699,6 @@ def render_filtered_data_section(filtered_df, use_expander=True):
         SGLANG_GRAFANA_DASHBOARDS = {
             "H200_OLD": _SGLANG_H200_DASHBOARD,
             "H200_NEW": _SGLANG_H200_DASHBOARD,
-            "H200_HERA": _SGLANG_H200_DASHBOARD,
             "H200_HERA2": _SGLANG_H200_DASHBOARD,
         }
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -10694,7 +10694,8 @@ def render_filtered_data_section(filtered_df, use_expander=True):
 
         _SGLANG_H200_DASHBOARD = {
             "dashboard_id": "sglang-dcgm-metrics-psap-rhaiis-h200",
-            "dashboard_name": "sglang-dcgm-metrics-psap-rhaiis-h200",
+            "dashboard_name": "sglang-2b-dcgm-metrics-psap-rhaiis-h200",
+            "extra_params": "&var-cluster_name=$__all&var-model_name=$__all",
         }
         SGLANG_GRAFANA_DASHBOARDS = {
             "H200": _SGLANG_H200_DASHBOARD,

--- a/dashboard.py
+++ b/dashboard.py
@@ -10755,10 +10755,15 @@ def render_filtered_data_section(filtered_df, use_expander=True):
                 else:
                     return None
 
-                is_sglang = isinstance(version, str) and version.lower().startswith("sglang")
+                is_sglang = isinstance(version, str) and version.lower().startswith(
+                    "sglang"
+                )
                 if is_sglang:
                     sglang_key = dashboard_key
-                    if sglang_key not in SGLANG_GRAFANA_DASHBOARDS and sglang_key.startswith("H200"):
+                    if (
+                        sglang_key not in SGLANG_GRAFANA_DASHBOARDS
+                        and sglang_key.startswith("H200")
+                    ):
                         sglang_key = "H200"
                     if sglang_key in SGLANG_GRAFANA_DASHBOARDS:
                         dashboard_config = SGLANG_GRAFANA_DASHBOARDS[sglang_key]

--- a/dashboard.py
+++ b/dashboard.py
@@ -10692,11 +10692,15 @@ def render_filtered_data_section(filtered_df, use_expander=True):
             },
         }
 
+        _SGLANG_H200_DASHBOARD = {
+            "dashboard_id": "sglang-dcgm-metrics-psap-rhaiis-h200",
+            "dashboard_name": "sglang-dcgm-metrics-psap-rhaiis-h200",
+        }
         SGLANG_GRAFANA_DASHBOARDS = {
-            "H200_NEW": {
-                "dashboard_id": "sglang-dcgm-metrics-psap-rhaiis-h200",
-                "dashboard_name": "sglang-dcgm-metrics-psap-rhaiis-h200",
-            },
+            "H200_OLD": _SGLANG_H200_DASHBOARD,
+            "H200_NEW": _SGLANG_H200_DASHBOARD,
+            "H200_HERA": _SGLANG_H200_DASHBOARD,
+            "H200_HERA2": _SGLANG_H200_DASHBOARD,
         }
 
         # Jan 1, 2026 00:00:00 UTC in milliseconds

--- a/dashboard.py
+++ b/dashboard.py
@@ -10697,8 +10697,7 @@ def render_filtered_data_section(filtered_df, use_expander=True):
             "dashboard_name": "sglang-dcgm-metrics-psap-rhaiis-h200",
         }
         SGLANG_GRAFANA_DASHBOARDS = {
-            "H200_OLD": _SGLANG_H200_DASHBOARD,
-            "H200_NEW": _SGLANG_H200_DASHBOARD,
+            "H200": _SGLANG_H200_DASHBOARD,
             "H200_HERA2": _SGLANG_H200_DASHBOARD,
         }
 
@@ -10758,8 +10757,11 @@ def render_filtered_data_section(filtered_df, use_expander=True):
 
                 is_sglang = isinstance(version, str) and version.lower().startswith("sglang")
                 if is_sglang:
-                    if dashboard_key in SGLANG_GRAFANA_DASHBOARDS:
-                        dashboard_config = SGLANG_GRAFANA_DASHBOARDS[dashboard_key]
+                    sglang_key = dashboard_key
+                    if sglang_key not in SGLANG_GRAFANA_DASHBOARDS and sglang_key.startswith("H200"):
+                        sglang_key = "H200"
+                    if sglang_key in SGLANG_GRAFANA_DASHBOARDS:
+                        dashboard_config = SGLANG_GRAFANA_DASHBOARDS[sglang_key]
                     else:
                         return None
                 else:

--- a/dashboard.py
+++ b/dashboard.py
@@ -10692,6 +10692,13 @@ def render_filtered_data_section(filtered_df, use_expander=True):
             },
         }
 
+        SGLANG_GRAFANA_DASHBOARDS = {
+            "H200_NEW": {
+                "dashboard_id": "sglang-dcgm-metrics-psap-rhaiis-h200",
+                "dashboard_name": "sglang-dcgm-metrics-psap-rhaiis-h200",
+            },
+        }
+
         # Jan 1, 2026 00:00:00 UTC in milliseconds
         H200_DASHBOARD_CUTOFF_MS = 1767225600000
 
@@ -10716,6 +10723,7 @@ def render_filtered_data_section(filtered_df, use_expander=True):
             uuid = row.get("uuid")
             accelerator = row.get("accelerator", "")
             run_name = row.get("run", "")
+            version = row.get("version", "")
 
             # Only create link if all required fields are present and not NaN
             if (
@@ -10745,7 +10753,15 @@ def render_filtered_data_section(filtered_df, use_expander=True):
                 else:
                     return None
 
-                dashboard_config = GRAFANA_DASHBOARDS[dashboard_key]
+                is_sglang = isinstance(version, str) and version.lower().startswith("sglang")
+                if is_sglang:
+                    if dashboard_key in SGLANG_GRAFANA_DASHBOARDS:
+                        dashboard_config = SGLANG_GRAFANA_DASHBOARDS[dashboard_key]
+                    else:
+                        return None
+                else:
+                    dashboard_config = GRAFANA_DASHBOARDS[dashboard_key]
+
                 dashboard_id = dashboard_config["dashboard_id"]
                 dashboard_name = dashboard_config["dashboard_name"]
                 extra_params = dashboard_config.get("extra_params", "")


### PR DESCRIPTION
## Summary
- Adds `SGLANG_GRAFANA_DASHBOARDS` dict mapping cluster keys to SGLang-specific Grafana dashboard IDs
- Updates `create_grafana_link` to detect SGLang runs via the `version` column (prefix "sglang") and route to the SGLang dashboard instead of the vLLM one
- Falls back to no link for clusters without an SGLang dashboard provisioned yet

Cherry-picked from PR #60 (targets main) to staging.

## Test plan
- [ ] Verify SGLang rows in the filtered data table show "View Metrics" links pointing to the SGLang Grafana dashboard
- [ ] Verify vLLM rows continue to link to the correct vLLM dashboard
- [ ] Verify rows with no matching dashboard show no link

🤖 Generated with [Claude Code](https://claude.com/claude-code)