### PR TITLE
Add H200_ZEUS2 Grafana dashboard mappings

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -10772,6 +10772,10 @@ def render_filtered_data_section(filtered_df, use_expander=True):
                 "dashboard_id": "psap-b200-mlperf",
                 "dashboard_name": "vllm-2b-dcgm-metrics-psap-b200-mlperf",
             },
+            "H200_ZEUS2": {
+                "dashboard_id": "d35f19c8f56250",
+                "dashboard_name": "vllm-2b-dcgm-metrics-psap-zeus-syd",
+            },
         }
 
         _SGLANG_H200_DASHBOARD = {
@@ -10782,6 +10786,7 @@ def render_filtered_data_section(filtered_df, use_expander=True):
         SGLANG_GRAFANA_DASHBOARDS = {
             "H200": _SGLANG_H200_DASHBOARD,
             "H200_HERA2": _SGLANG_H200_DASHBOARD,
+            "H200_ZEUS2": _SGLANG_H200_DASHBOARD,
         }
 
         # Jan 1, 2026 00:00:00 UTC in milliseconds


### PR DESCRIPTION
## Summary
- Add H200_ZEUS2 to vLLM `GRAFANA_DASHBOARDS` (dashboard UID `d35f19c8f56250`, slug `vllm-2b-dcgm-metrics-psap-zeus-syd`)
- Add H200_ZEUS2 to `SGLANG_GRAFANA_DASHBOARDS` (reuses existing shared SGLang dashboard)

## Test plan
- [ ] Verify ZEUS2 vLLM runs generate correct Grafana links
- [ ] Verify ZEUS2 SGLang runs generate correct Grafana links

🤖 Generated with [Claude Code](https://claude.com/claude-code)