### PR TITLE
Add CSV download buttons to Compare Versions and Filtered Data (staging)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -6870,10 +6870,17 @@ def render_compare_versions_summary_section(df, use_expander=True):
             )
 
             csv_data = summary_df.to_csv(index=False).encode("utf-8")
+            _raw = f"compare_{version_1}_vs_{version_2}_{selected_accelerator}_{profile_short}"
+            safe_name = (
+                _raw.replace("/", "-")
+                .replace(" ", "_")
+                .replace("(", "")
+                .replace(")", "")
+            )
             st.download_button(
                 label="📥 Download Table as CSV",
                 data=csv_data,
-                file_name=f"compare_{version_1}_vs_{version_2}_{selected_accelerator}_{profile_short}.csv",
+                file_name=f"{safe_name}.csv",
                 mime="text/csv",
                 key="compare_versions_csv_download",
             )
@@ -7060,8 +7067,16 @@ def render_compare_versions_summary_section(df, use_expander=True):
                             if row["Metric"]
                             != "Total Throughput (input + output tok/s)"
                         ]
-                        v1_ttft_median_s = v1_ttft_median / 1000 if pd.notna(v1_ttft_median) else v1_ttft_median
-                        v2_ttft_median_s = v2_ttft_median / 1000 if pd.notna(v2_ttft_median) else v2_ttft_median
+                        v1_ttft_median_s = (
+                            v1_ttft_median / 1000
+                            if pd.notna(v1_ttft_median)
+                            else v1_ttft_median
+                        )
+                        v2_ttft_median_s = (
+                            v2_ttft_median / 1000
+                            if pd.notna(v2_ttft_median)
+                            else v2_ttft_median
+                        )
                         detail_rows.append(
                             {
                                 "Metric": f"TTFT Median{latency_conc_label}",

--- a/dashboard.py
+++ b/dashboard.py
@@ -6869,6 +6869,15 @@ def render_compare_versions_summary_section(df, use_expander=True):
                 column_config=column_config,
             )
 
+            csv_data = summary_df.to_csv(index=False).encode("utf-8")
+            st.download_button(
+                label="📥 Download Table as CSV",
+                data=csv_data,
+                file_name=f"compare_{version_1}_vs_{version_2}_{selected_accelerator}_{profile_short}.csv",
+                mime="text/csv",
+                key="compare_versions_csv_download",
+            )
+
             # Legend
             st.markdown("---")
             st.markdown(
@@ -11151,6 +11160,15 @@ def render_filtered_data_section(filtered_df, use_expander=True):
             column_config=column_config,
             disabled=disabled_cols,
             key="filtered_data_table",
+        )
+
+        csv_data = display_filtered_df.to_csv(index=False).encode("utf-8")
+        st.download_button(
+            label="📥 Download Filtered Data as CSV",
+            data=csv_data,
+            file_name="filtered_data.csv",
+            mime="text/csv",
+            key="filtered_data_csv_download",
         )
 
         checked = edited_df[edited_df["view_logs_link"]]


### PR DESCRIPTION
## Summary
- Added "📥 Download Table as CSV" button below the Compare Versions summary table
- Added "📥 Download Filtered Data as CSV" button below the Filtered Data table

## Test plan
- [ ] `ruff check dashboard.py` passes
- [ ] Compare Versions: download button appears below table, CSV contains correct data
- [ ] Filtered Data: download button appears below table, CSV matches displayed rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)