### PR TITLE
Add CSV download buttons to Compare Versions and Filtered Data

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -6806,6 +6806,15 @@ def render_compare_versions_summary_section(df, use_expander=True):
                 column_config=column_config,
             )
 
+            csv_data = summary_df.to_csv(index=False).encode("utf-8")
+            st.download_button(
+                label="📥 Download Table as CSV",
+                data=csv_data,
+                file_name=f"compare_{version_1}_vs_{version_2}_{selected_accelerator}_{profile_short}.csv",
+                mime="text/csv",
+                key="compare_versions_csv_download",
+            )
+
             # Legend
             st.markdown("---")
             st.markdown(
@@ -11036,6 +11045,15 @@ def render_filtered_data_section(filtered_df, use_expander=True):
             column_config=column_config,
             disabled=disabled_cols,
             key="filtered_data_table",
+        )
+
+        csv_data = display_filtered_df.to_csv(index=False).encode("utf-8")
+        st.download_button(
+            label="📥 Download Filtered Data as CSV",
+            data=csv_data,
+            file_name="filtered_data.csv",
+            mime="text/csv",
+            key="filtered_data_csv_download",
         )
 
         checked = edited_df[edited_df["view_logs_link"]]

--- a/dashboard.py
+++ b/dashboard.py
@@ -6807,10 +6807,17 @@ def render_compare_versions_summary_section(df, use_expander=True):
             )
 
             csv_data = summary_df.to_csv(index=False).encode("utf-8")
+            _raw = f"compare_{version_1}_vs_{version_2}_{selected_accelerator}_{profile_short}"
+            safe_name = (
+                _raw.replace("/", "-")
+                .replace(" ", "_")
+                .replace("(", "")
+                .replace(")", "")
+            )
             st.download_button(
                 label="📥 Download Table as CSV",
                 data=csv_data,
-                file_name=f"compare_{version_1}_vs_{version_2}_{selected_accelerator}_{profile_short}.csv",
+                file_name=f"{safe_name}.csv",
                 mime="text/csv",
                 key="compare_versions_csv_download",
             )


### PR DESCRIPTION
## Summary
- Added "📥 Download Table as CSV" button below the Compare Versions summary table
- Added "📥 Download Filtered Data as CSV" button below the Filtered Data table

## Test plan
- [ ] `ruff check dashboard.py` passes
- [ ] Compare Versions: download button appears below table, CSV contains correct data
- [ ] Filtered Data: download button appears below table, CSV matches displayed rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV download buttons for the Compare Versions summary and Filtered Data tables.
  * Downloads use section-specific filenames and CSV formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->