### PR TITLE
Add Profile F: Heavy Heterogeneous (8k/800)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -462,6 +462,7 @@ def assign_profile_vectorized(df):
         (prompt == 2048) & (output == 128),
         (prompt == 8000) & (output == 1000),
         (prompt == 100000) & (output == 1000),
+        (prompt == 8000) & (output == 800),
     ]
     choices = [
         "Profile A: Balanced (1k/1k)",
@@ -469,6 +470,7 @@ def assign_profile_vectorized(df):
         "Profile C: Large Prompt (2k/128)",
         "Profile D: Prefill Heavy (8k/1k)",
         "Profile E: Long Context (100k/1k)",
+        "Profile F: Heavy Heterogeneous (8k/800)",
     ]
     return np.select(conditions, choices, default="Custom ISL/OSL")
 


### PR DESCRIPTION
## Summary
- Adds `Profile F: Heavy Heterogeneous (8k/800)` to `assign_profile_vectorized()` so 8000/800 token pairs get a named profile instead of falling through to Custom ISL/OSL in the dropdown and chart labels.

## Test plan
- [ ] Run dashboard locally, verify 8k/800 data shows as "Profile F: Heavy Heterogeneous (8k/800)" in sidebar and charts
- [ ] Verify existing profiles (A–E) are unaffected
- [ ] `ruff check dashboard.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)