### PR TITLE
Add RHAIIS 3.5-GA overview release pairs

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -102,6 +102,18 @@ OVERVIEW_ADDITIONAL: list[str] = []
 OVERVIEW_RELEASE_PAIRS = [
     # ── RHAIIS 3.5 release pairs ────────────────────────────────────
     {
+        "current": "RHAIIS-3.5-GA",
+        "previous": "RHAIIS-3.4-GA",
+        "upstream": "vLLM-0.24.0",
+        "additional": [],
+    },
+    {
+        "current": "RHAIIS-3.5-GA",
+        "previous": "RHAIIS-3.5-EA2",
+        "upstream": "vLLM-0.24.0",
+        "additional": [],
+    },
+    {
         "current": "RHAIIS-3.5-EA2",
         "previous": "RHAIIS-3.5-EA1",
         "upstream": "vLLM-0.21.0",
@@ -7051,8 +7063,16 @@ def render_compare_versions_summary_section(df, use_expander=True):
                             if row["Metric"]
                             != "Total Throughput (input + output tok/s)"
                         ]
-                        v1_ttft_median_s = v1_ttft_median / 1000 if pd.notna(v1_ttft_median) else v1_ttft_median
-                        v2_ttft_median_s = v2_ttft_median / 1000 if pd.notna(v2_ttft_median) else v2_ttft_median
+                        v1_ttft_median_s = (
+                            v1_ttft_median / 1000
+                            if pd.notna(v1_ttft_median)
+                            else v1_ttft_median
+                        )
+                        v2_ttft_median_s = (
+                            v2_ttft_median / 1000
+                            if pd.notna(v2_ttft_median)
+                            else v2_ttft_median
+                        )
                         detail_rows.append(
                             {
                                 "Metric": f"TTFT Median{latency_conc_label}",


### PR DESCRIPTION
## Summary
- Adds two new Overview comparisons for the RHAIIS 3.5-GA release:
  - **RHAIIS-3.5-GA vs RHAIIS-3.4-GA** (upstream: vLLM-0.24.0)
  - **RHAIIS-3.5-GA vs RHAIIS-3.5-EA2** (upstream: vLLM-0.24.0)
- Profiles (100k/1k, profile 7, etc.) are auto-discovered from data — any profile present in both versions will appear automatically

## Test plan
- [ ] Verify "RHAIIS-3.5-GA vs RHAIIS-3.4-GA" appears as the default selection in the Overview dropdown
- [ ] Verify "RHAIIS-3.5-GA vs RHAIIS-3.5-EA2" appears as the second option
- [ ] Verify existing release pairs are preserved and unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)