### PR TITLE
Add RHAIIS 3.5-GA overview release pairs

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -100,6 +100,18 @@ OVERVIEW_ADDITIONAL: list[str] = []
 # vLLM parity data isn't available for that release.
 OVERVIEW_RELEASE_PAIRS = [
     {
+        "current": "RHAIIS-3.5-GA",
+        "previous": "RHAIIS-3.4-GA",
+        "upstream": "vLLM-0.24.0",
+        "additional": [],
+    },
+    {
+        "current": "RHAIIS-3.5-GA",
+        "previous": "RHAIIS-3.5-EA2",
+        "upstream": "vLLM-0.24.0",
+        "additional": [],
+    },
+    {
         "current": "RHAIIS-3.5-EA2",
         "previous": "RHAIIS-3.5-EA1",
         "upstream": "vLLM-0.21.0",


### PR DESCRIPTION
## Summary
- Adds two new Overview comparisons for the RHAIIS 3.5-GA release:
  - **RHAIIS-3.5-GA vs RHAIIS-3.4-GA** (upstream: vLLM-0.24.0)
  - **RHAIIS-3.5-GA vs RHAIIS-3.5-EA2** (upstream: vLLM-0.24.0)
- Profiles (100k/1k, profile 7, etc.) are auto-discovered from data — any profile present in both versions will appear automatically

## Test plan
- [ ] Verify "RHAIIS-3.5-GA vs RHAIIS-3.4-GA" appears as the default selection in the Overview dropdown
- [ ] Verify "RHAIIS-3.5-GA vs RHAIIS-3.5-EA2" appears as the second option
- [ ] Verify existing release pairs are preserved and unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Overview comparisons for the RHAIIS 3.5 GA release against:
    * RHAIIS 3.4 GA
    * RHAIIS 3.5 EA2
  * Both comparisons now include the vLLM 0.24.0 release pairing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->